### PR TITLE
Daschult/simplify polymorphism

### DIFF
--- a/lib/serialization/dictionarySpec.ts
+++ b/lib/serialization/dictionarySpec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 import { PropertyPath } from "./propertyPath";
-import { SerializationOptions, failDeserializeTypeCheck, failSerializeTypeCheck, resolveValueSpec } from "./serializationOptions";
+import { SerializationOptions, failDeserializeTypeCheck, failSerializeTypeCheck, resolveTypeSpec } from "./serializationOptions";
 import { TypeSpec } from "./typeSpec";
 
 export interface DictionaryType<T> {
@@ -30,7 +30,7 @@ export function dictionarySpec<TSerializedValue, TDeserializedValue>(valueSpec: 
         failSerializeTypeCheck(options, propertyPath, value, "an object");
         result = value as any;
       } else {
-        const valueTypeSpec: TypeSpec<TSerializedValue, TDeserializedValue> = resolveValueSpec(options, propertyPath, valueSpec);
+        const valueTypeSpec: TypeSpec<TSerializedValue, TDeserializedValue> = resolveTypeSpec(options, propertyPath, valueSpec);
         result = {};
         for (const key in value) {
           result[key] = valueTypeSpec.serialize(propertyPath.concat([key]), value[key], options);
@@ -46,7 +46,7 @@ export function dictionarySpec<TSerializedValue, TDeserializedValue>(valueSpec: 
         failDeserializeTypeCheck(options, propertyPath, value, "an object");
         result = value as any;
       } else {
-        const valueTypeSpec: TypeSpec<TSerializedValue, TDeserializedValue> = resolveValueSpec(options, propertyPath, valueSpec);
+        const valueTypeSpec: TypeSpec<TSerializedValue, TDeserializedValue> = resolveTypeSpec(options, propertyPath, valueSpec);
         result = {};
         for (const key in value) {
           result[key] = valueTypeSpec.deserialize(propertyPath.concat([key]), value[key], options);

--- a/lib/serialization/sequenceSpec.ts
+++ b/lib/serialization/sequenceSpec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 import { PropertyPath } from "./propertyPath";
-import { SerializationOptions, failDeserializeTypeCheck, failSerializeTypeCheck, resolveValueSpec } from "./serializationOptions";
+import { SerializationOptions, failDeserializeTypeCheck, failSerializeTypeCheck, resolveTypeSpec } from "./serializationOptions";
 import { TypeSpec } from "./typeSpec";
 
 export interface SequenceTypeSpec<TSerializedElement, TDeserializedElement> extends TypeSpec<TSerializedElement[], TDeserializedElement[]> {
@@ -26,7 +26,7 @@ export function sequenceSpec<TSerializedElement, TDeserializedElement>(elementSp
         failSerializeTypeCheck(options, propertyPath, value, "an Array");
         result = value;
       } else {
-        const elementTypeSpec: TypeSpec<TSerializedElement, TDeserializedElement> = resolveValueSpec(options, propertyPath, elementSpec);
+        const elementTypeSpec: TypeSpec<TSerializedElement, TDeserializedElement> = resolveTypeSpec(options, propertyPath, elementSpec);
         result = [];
         for (let i = 0; i < value.length; i++) {
           result[i] = elementTypeSpec.serialize(propertyPath.concat([i.toString()]), value[i], options);
@@ -41,7 +41,7 @@ export function sequenceSpec<TSerializedElement, TDeserializedElement>(elementSp
         failDeserializeTypeCheck(options, propertyPath, value, "an Array");
         result = value;
       } else {
-        const elementTypeSpec: TypeSpec<TSerializedElement, TDeserializedElement> = resolveValueSpec(options, propertyPath, elementSpec);
+        const elementTypeSpec: TypeSpec<TSerializedElement, TDeserializedElement> = resolveTypeSpec(options, propertyPath, elementSpec);
         result = [];
         for (let i = 0; i < value.length; i++) {
           result[i] = elementTypeSpec.deserialize(propertyPath.concat([i.toString()]), value[i], options);

--- a/lib/serialization/serializationOptions.ts
+++ b/lib/serialization/serializationOptions.ts
@@ -4,6 +4,7 @@ import { HttpPipelineLogLevel } from "../httpPipelineLogLevel";
 import { HttpPipelineLogger } from "../httpPipelineLogger";
 import { CompositeTypeSpec } from "./compositeSpec";
 import { PropertyPath } from "./propertyPath";
+import { TypeSpec } from "./typeSpec";
 
 /**
  * Options that can be passed to a serialize() function.
@@ -166,16 +167,21 @@ export function logAndCreateError(serializationOptions: SerializationOptions, er
   return new Error(errorMessage);
 }
 
-export function resolveValueSpec<T>(serializationOptions: SerializationOptions, path: PropertyPath, valueSpec: T | string): T {
-  let result: T;
-  if (typeof valueSpec === "string") {
-    if (!serializationOptions.compositeSpecDictionary || !serializationOptions.compositeSpecDictionary[valueSpec]) {
-      throw logAndCreateError(serializationOptions, `Missing composite specification entry in composite type dictionary for type named "${valueSpec}" at ${path}.`);
+export function resolveTypeSpec<TSerialized, TDeserialized>(serializationOptions: SerializationOptions, path: PropertyPath, typeSpec: TypeSpec<TSerialized, TDeserialized> | string): TypeSpec<TSerialized, TDeserialized> {
+  let result: TypeSpec<TSerialized, TDeserialized>;
+  if (typeof typeSpec === "string") {
+    if (!serializationOptions.compositeSpecDictionary || !serializationOptions.compositeSpecDictionary[typeSpec]) {
+      throw logAndCreateError(serializationOptions, `Missing composite specification entry in composite type dictionary for type named "${typeSpec}" at ${path}.`);
     } else {
-      result = serializationOptions.compositeSpecDictionary[valueSpec] as any;
+      result = serializationOptions.compositeSpecDictionary[typeSpec] as any;
     }
   } else {
-    result = valueSpec;
+    result = typeSpec;
   }
   return result;
 }
+
+export function resolveCompositeTypeSpec(serializationOptions: SerializationOptions, path: PropertyPath, valueSpec: CompositeTypeSpec | string): CompositeTypeSpec {
+  return resolveTypeSpec(serializationOptions, path, valueSpec) as CompositeTypeSpec;
+}
+

--- a/test/shared/serialization/compositeSpecTests.ts
+++ b/test/shared/serialization/compositeSpecTests.ts
@@ -100,10 +100,10 @@ describe("compositeSpec", () => {
             derivedTypeSpec: "Cat",
             discriminatorPropertyValue: "cat"
           }
-        ],
-        discriminatorPropertyName: "animalType",
-        discriminatorPropertyValue: "animal"
-      }
+        ]
+      },
+      discriminatorPropertyName: "animalType",
+      discriminatorPropertyValue: "animal"
     },
     propertySpecs: {
       animalType: {
@@ -127,10 +127,10 @@ describe("compositeSpec", () => {
             derivedTypeSpec: "Tiger",
             discriminatorPropertyValue: "tiger"
           }
-        ],
-        discriminatorPropertyName: "animalType",
-        discriminatorPropertyValue: "cat"
-      }
+        ]
+      },
+      discriminatorPropertyName: "animalType",
+      discriminatorPropertyValue: "cat"
     },
     propertySpecs: {
       cuddly: {
@@ -151,10 +151,10 @@ describe("compositeSpec", () => {
             derivedTypeSpec: "Saber-toothed Tiger",
             discriminatorPropertyValue: "saber"
           }
-        ],
-        discriminatorPropertyName: "toothType",
-        discriminatorPropertyValue: "sharp"
-      }
+        ]
+      },
+      discriminatorPropertyName: "animalType",
+      discriminatorPropertyValue: "tiger"
     },
     propertySpecs: {
       stripes: {
@@ -171,7 +171,9 @@ describe("compositeSpec", () => {
   const saberToothedTiger: CompositeTypeSpec = compositeSpec({
     typeName: "Saber-toothed Tiger",
     polymorphism: {
-      inheritsFrom: [tiger]
+      inheritsFrom: [tiger],
+      discriminatorPropertyName: "animalType",
+      discriminatorPropertyValue: "saber-toothed tiger"
     }
   });
 
@@ -577,14 +579,14 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
-        expectedResult: new Error(`Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`),
-        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedResult: new Error(`Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`),
+        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeSerializeWithStrictTypeCheckingTest({
@@ -596,20 +598,17 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
         expectedResult: {
-          animalType: "tiger",
-          toothType: "terrifying",
-          ageInYears: 12,
-          stripes: 20,
-          cuddly: true
+          animalType: "lion",
+          ageInYears: 12
         },
-        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeSerializeWithStrictTypeCheckingTest({
@@ -1119,14 +1118,14 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
-        expectedResult: new Error(`Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`),
-        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedResult: new Error(`Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`),
+        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeSerializeWithoutStrictTypeCheckingTest({
@@ -1138,20 +1137,17 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
         expectedResult: {
-          animalType: "tiger",
-          toothType: "terrifying",
+          animalType: "lion",
           ageInYears: 12,
-          stripes: 20,
-          cuddly: true
         },
-        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeSerializeWithoutStrictTypeCheckingTest({
@@ -1671,14 +1667,14 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
-        expectedResult: new Error(`Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`),
-        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedResult: new Error(`Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`),
+        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeDeserializeWithStrictTypeCheckingTest({
@@ -1690,20 +1686,17 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
         expectedResult: {
-          animalType: "tiger",
-          toothType: "terrifying",
-          ageInYears: 12,
-          stripes: 20,
-          cuddly: true
+          animalType: "lion",
+          ageInYears: 12
         },
-        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeDeserializeWithStrictTypeCheckingTest({
@@ -2212,14 +2205,14 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
-        expectedResult: new Error(`Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`),
-        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedResult: new Error(`Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`),
+        expectedLogs: [`ERROR: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeDeserializeWithoutStrictTypeCheckingTest({
@@ -2231,20 +2224,17 @@ describe("compositeSpec", () => {
         },
         compositeSpec: animal,
         value: {
-          animalType: "tiger",
+          animalType: "lion",
           toothType: "terrifying",
           ageInYears: 12,
           stripes: 20,
           cuddly: true
         },
         expectedResult: {
-          animalType: "tiger",
-          toothType: "terrifying",
-          ageInYears: 12,
-          stripes: 20,
-          cuddly: true
+          animalType: "lion",
+          ageInYears: 12
         },
-        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value terrifying for composite type Tiger at property a.property.path.toothType.`]
+        expectedLogs: [`WARNING: Unrecognized polymorphic discriminator value lion for composite type Animal at property a.property.path.animalType.`]
       });
 
       compositeDeserializeWithoutStrictTypeCheckingTest({

--- a/test/shared/serialization/compositeSpecTests.ts
+++ b/test/shared/serialization/compositeSpecTests.ts
@@ -94,14 +94,7 @@ describe("compositeSpec", () => {
   const animal: CompositeTypeSpec = compositeSpec({
     typeName: "Animal",
     polymorphism: {
-      inheritedBy: {
-        derivedTypes: [
-          {
-            derivedTypeSpec: "Cat",
-            discriminatorPropertyValue: "cat"
-          }
-        ]
-      },
+      inheritedBy: ["Cat"],
       discriminatorPropertyName: "animalType",
       discriminatorPropertyValue: "animal"
     },
@@ -120,15 +113,8 @@ describe("compositeSpec", () => {
   const cat: CompositeTypeSpec = compositeSpec({
     typeName: "Cat",
     polymorphism: {
-      inheritsFrom: animal,
-      inheritedBy: {
-        derivedTypes: [
-          {
-            derivedTypeSpec: "Tiger",
-            discriminatorPropertyValue: "tiger"
-          }
-        ]
-      },
+      inheritsFrom: [animal],
+      inheritedBy: ["Tiger"],
       discriminatorPropertyName: "animalType",
       discriminatorPropertyValue: "cat"
     },
@@ -145,14 +131,7 @@ describe("compositeSpec", () => {
     polymorphism: {
       // This is just to make sure that a diamond inheritance model works.
       inheritsFrom: [cat, animal],
-      inheritedBy: {
-        derivedTypes: [
-          {
-            derivedTypeSpec: "Saber-toothed Tiger",
-            discriminatorPropertyValue: "saber"
-          }
-        ]
-      },
+      inheritedBy: ["Saber-toothed Tiger"],
       discriminatorPropertyName: "animalType",
       discriminatorPropertyValue: "tiger"
     },

--- a/test/shared/serialization/compositeSpecTests.ts
+++ b/test/shared/serialization/compositeSpecTests.ts
@@ -113,9 +113,8 @@ describe("compositeSpec", () => {
   const cat: CompositeTypeSpec = compositeSpec({
     typeName: "Cat",
     polymorphism: {
-      inheritsFrom: [animal],
+      inheritsFrom: animal,
       inheritedBy: ["Tiger"],
-      discriminatorPropertyName: "animalType",
       discriminatorPropertyValue: "cat"
     },
     propertySpecs: {
@@ -129,10 +128,8 @@ describe("compositeSpec", () => {
   const tiger: CompositeTypeSpec = compositeSpec({
     typeName: "Tiger",
     polymorphism: {
-      // This is just to make sure that a diamond inheritance model works.
-      inheritsFrom: [cat, animal],
+      inheritsFrom: cat,
       inheritedBy: ["Saber-toothed Tiger"],
-      discriminatorPropertyName: "animalType",
       discriminatorPropertyValue: "tiger"
     },
     propertySpecs: {
@@ -150,8 +147,7 @@ describe("compositeSpec", () => {
   const saberToothedTiger: CompositeTypeSpec = compositeSpec({
     typeName: "Saber-toothed Tiger",
     polymorphism: {
-      inheritsFrom: [tiger],
-      discriminatorPropertyName: "animalType",
+      inheritsFrom: tiger,
       discriminatorPropertyValue: "saber-toothed tiger"
     }
   });


### PR DESCRIPTION
After talking with @amarzavery more about polymorphism and after starting to work on the generator, I realized that CompositeTypeSpec handled way more cases than is necessary (multiple inheritance and multiple discriminator properties). I feel that keeping things as simple as possible allows more flexibility in the future, so this PR removes those capabilities. A bonus perk is that is makes the Polymorphism object much smaller and more readable.