### PR TITLE
Re-enable string representations of HttpMethod enum values in HttpRequest

### DIFF
--- a/lib/httpRequest.ts
+++ b/lib/httpRequest.ts
@@ -18,7 +18,7 @@ export interface HttpRequestParameters {
   /**
    * The HTTP method of the request.
    */
-  method: HttpMethod;
+  method: HttpMethod | keyof typeof HttpMethod;
 
   /**
    * The URL that the request will be sent to.
@@ -53,7 +53,7 @@ export class HttpRequest {
   /**
    * The HTTP method of this request.
    */
-  public method: HttpMethod;
+  public method: HttpMethod | keyof typeof HttpMethod;
 
   /**
    * The URL that this request will be sent to.

--- a/test/shared/httpRequestTests.ts
+++ b/test/shared/httpRequestTests.ts
@@ -52,4 +52,22 @@ describe("HttpRequest", () => {
       assert.strictEqual(httpRequest.serializedBody, undefined);
     });
   });
+
+  describe("method", () => {
+    it("should allow HttpMethod enum values", () => {
+      const httpRequest = new HttpRequest({ method: HttpMethod.DELETE, url: "www.example.com" });
+      assert.strictEqual(httpRequest.method, HttpMethod.DELETE);
+      assert.strictEqual(httpRequest.method, "DELETE");
+      assert(httpRequest.method === HttpMethod.DELETE);
+      assert(httpRequest.method === "DELETE");
+    });
+
+    it("should allow string versions of HttpMethod enum values", () => {
+      const httpRequest = new HttpRequest({ method: "DELETE", url: "www.example.com" });
+      assert.strictEqual(httpRequest.method, HttpMethod.DELETE);
+      assert.strictEqual(httpRequest.method, "DELETE");
+      assert(httpRequest.method === HttpMethod.DELETE);
+      assert(httpRequest.method === "DELETE");
+    });
+  });
 });

--- a/test/shared/httpRequestTests.ts
+++ b/test/shared/httpRequestTests.ts
@@ -60,6 +60,10 @@ describe("HttpRequest", () => {
       assert.strictEqual(httpRequest.method, "DELETE");
       assert(httpRequest.method === HttpMethod.DELETE);
       assert(httpRequest.method === "DELETE");
+
+      const method: HttpMethod = httpRequest.method as HttpMethod;
+      assert(method === HttpMethod.DELETE);
+      assert(method === "DELETE");
     });
 
     it("should allow string versions of HttpMethod enum values", () => {
@@ -68,6 +72,10 @@ describe("HttpRequest", () => {
       assert.strictEqual(httpRequest.method, "DELETE");
       assert(httpRequest.method === HttpMethod.DELETE);
       assert(httpRequest.method === "DELETE");
+
+      const method: HttpMethod = httpRequest.method as HttpMethod;
+      assert(method === HttpMethod.DELETE);
+      assert(method === "DELETE");
     });
   });
 });


### PR DESCRIPTION
@RikkiGibson was right. I was definitely having issues with this previously, but I can't seem to reproduce those issues now.