### PR TITLE
Remove ServiceClient.pipeline() in favor of ServiceClient.sendRequest()

### DIFF
--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -108,16 +108,6 @@ export class ServiceClient {
     this._requestPolicyCreators = options.requestPolicyCreators || createDefaultRequestPolicyCreators(credentials, options, this.userAgentInfo.value);
   }
 
-  pipeline(request: WebResource): Promise<HttpOperationResponse> {
-    let httpPipeline: RequestPolicy = this._httpClient;
-    if (this._requestPolicyCreators && this._requestPolicyCreators.length > 0) {
-      for (let i = this._requestPolicyCreators.length - 1; i >= 0; --i) {
-        httpPipeline = this._requestPolicyCreators[i](httpPipeline, this._requestPolicyOptions);
-      }
-    }
-    return httpPipeline.sendRequest(request);
-  }
-
   /**
    * Adds custom information to user agent header
    * @param {any} additionalUserAgentInfo - information to be added to user agent header, as string.
@@ -149,7 +139,13 @@ export class ServiceClient {
     // send request
     let operationResponse: HttpOperationResponse;
     try {
-      operationResponse = await this.pipeline(httpRequest);
+      let httpPipeline: RequestPolicy = this._httpClient;
+      if (this._requestPolicyCreators && this._requestPolicyCreators.length > 0) {
+        for (let i = this._requestPolicyCreators.length - 1; i >= 0; --i) {
+          httpPipeline = this._requestPolicyCreators[i](httpPipeline, this._requestPolicyOptions);
+        }
+      }
+      operationResponse = await httpPipeline.sendRequest(httpRequest);
     } catch (err) {
       return Promise.reject(err);
     }

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -39,11 +39,18 @@ export class WebResource {
    * mentioned properties are not defined.
    */
   validateRequestProperties(): void {
-    if (!this.method || !this.url || !this.headers["Content-Type"] || !this.headers["accept-language"]) {
-      throw new Error("method, url, headers[\"Content-Type\"], headers[\"accept-language\"] are " +
-        "required properties before making a request. Either provide them or use WebResource.prepare() method.");
+    if (!this.method) {
+      throw new Error("method is a required property for making a request.");
     }
-    return;
+    if (!this.url) {
+      throw new Error("url is a required property for making a request.");
+    }
+    if (!this.headers["Content-Type"]) {
+      throw new Error("'Content-Type' is a required header for making a request.");
+    }
+    // if (!this.headers["accept-language"]) {
+    //   throw new Error("'accept-language' is a required header for making a request.");
+    // }
   }
 
   /**


### PR DESCRIPTION
This is an attempt to simplify the ServiceClient public API. I understand that ServiceClient.sendRequest() has a bit of redundant validation at this point, but as I do more work to push computation into the runtime, this redundancy will go away.