### PR TITLE
Don't expose fetch types in HttpOperationResponse

### DIFF
--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -49,8 +49,13 @@ export class FetchHttpClient implements HttpClient {
       httpRequest.body = requestForm;
       httpRequest.formData = undefined;
       if (httpRequest.headers && httpRequest.headers["Content-Type"] &&
-        httpRequest.headers["Content-Type"].indexOf("multipart/form-data") > -1 && typeof requestForm.getBoundary === "function") {
-        httpRequest.headers["Content-Type"] = `multipart/form-data; boundary=${requestForm.getBoundary()}`;
+          httpRequest.headers["Content-Type"].indexOf("multipart/form-data") !== -1) {
+        if (typeof requestForm.getBoundary === "function") {
+          httpRequest.headers["Content-Type"] = `multipart/form-data; boundary=${requestForm.getBoundary()}`;
+        } else {
+          // browser will automatically apply a suitable content-type header
+          delete httpRequest.headers["Content-Type"];
+        }
       }
     }
 

--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -75,7 +75,7 @@ export class FetchHttpClient implements HttpClient {
       status: res.status,
       headers,
       readableStreamBody: isNode ? res.body as any : undefined,
-      blobBody: isNode ? undefined : res.blob
+      blobBody: isNode ? undefined : () => res.blob()
     };
 
     if (!httpRequest.rawResponse) {

--- a/lib/httpHeaders.ts
+++ b/lib/httpHeaders.ts
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+/**
+ * A collection of HttpHeaders that can be sent with a HTTP request.
+ */
+function getHeaderKey(headerName: string) {
+  return headerName.toLowerCase();
+}
+
+/**
+ * An individual header within a HttpHeaders collection.
+ */
+export interface HttpHeader {
+  /**
+   * The name of the header.
+   */
+  name: string;
+
+  /**
+   * The value of the header.
+   */
+  value: string;
+}
+
+/**
+ * A HttpHeaders collection represented as a simple JSON object.
+ */
+export type RawHttpHeaders = { [headerName: string]: string };
+
+/**
+ * A collection of HTTP header key/value pairs.
+ */
+export class HttpHeaders {
+  private readonly _headersMap: { [headerKey: string]: HttpHeader };
+
+  constructor(rawHeaders?: RawHttpHeaders) {
+    this._headersMap = {};
+    if (rawHeaders) {
+      for (const headerName in rawHeaders) {
+        this.set(headerName, rawHeaders[headerName]);
+      }
+    }
+  }
+
+  /**
+   * Set a header in this collection with the provided name and value. The name is
+   * case-insensitive.
+   * @param headerName The name of the header to set. This value is case-insensitive.
+   * @param headerValue The value of the header to set.
+   */
+  public set(headerName: string, headerValue: string | number): void {
+    this._headersMap[getHeaderKey(headerName)] = { name: headerName, value: headerValue.toString() };
+  }
+
+  /**
+   * Get the header value for the provided header name, or undefined if no header exists in this
+   * collection with the provided name.
+   * @param headerName The name of the header.
+   */
+  public get(headerName: string): string | undefined {
+    const header: HttpHeader = this._headersMap[getHeaderKey(headerName)];
+    return !header ? undefined : header.value;
+  }
+
+  /**
+   * Get whether or not this header collection contains a header entry for the provided header name.
+   */
+  public contains(headerName: string): boolean {
+    return !!this._headersMap[getHeaderKey(headerName)];
+  }
+
+  /**
+   * Remove the header with the provided headerName. Return whether or not the header existed and
+   * was removed.
+   * @param headerName The name of the header to remove.
+   */
+  public remove(headerName: string): boolean {
+    const result: boolean = this.contains(headerName);
+    delete this._headersMap[getHeaderKey(headerName)];
+    return result;
+  }
+
+  /**
+   * Get the headers that are contained this collection as an object.
+   */
+  public rawHeaders(): RawHttpHeaders {
+    const result: RawHttpHeaders = {};
+    for (const headerKey in this._headersMap) {
+      const header: HttpHeader = this._headersMap[headerKey];
+      result[header.name] = header.value;
+    }
+    return result;
+  }
+
+  /**
+   * Get the headers that are contained in this collection as an array.
+   */
+  public headersArray(): HttpHeader[] {
+    const headers: HttpHeader[] = [];
+    for (const headerKey in this._headersMap) {
+      headers.push(this._headersMap[headerKey]);
+    }
+    return headers;
+  }
+
+  /**
+   * Get the header names that are contained in this collection.
+   */
+  public headerNames(): string[] {
+    const headerNames: string[] = [];
+    const headers: HttpHeader[] = this.headersArray();
+    for (let i = 0; i < headers.length; ++i) {
+      headerNames.push(headers[i].name);
+    }
+    return headerNames;
+  }
+
+  /**
+   * Get the header names that are contained in this collection.
+   */
+  public headerValues(): string[] {
+    const headerValues: string[] = [];
+    const headers: HttpHeader[] = this.headersArray();
+    for (let i = 0; i < headers.length; ++i) {
+      headerValues.push(headers[i].value);
+    }
+    return headerValues;
+  }
+
+  /**
+   * Get the JSON object representation of this HTTP header collection.
+   */
+  public toJson(): RawHttpHeaders {
+    const result: RawHttpHeaders = {};
+
+    const headers: HttpHeader[] = this.headersArray();
+    for (let i = 0; i < headers.length; ++i) {
+      result[headers[i].name] = headers[i].value;
+    }
+
+    return result;
+  }
+
+  /**
+   * Create a deep clone/copy of this HttpHeaders collection.
+   */
+  public clone(): HttpHeaders {
+    return new HttpHeaders(this.rawHeaders());
+  }
+}

--- a/lib/httpOperationResponse.ts
+++ b/lib/httpOperationResponse.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { WebResource } from "./webResource";
+import { HttpHeaders } from "./httpHeaders";
 
 /**
  * Wrapper object for http request and response. Deserialized object is stored in
@@ -10,15 +11,22 @@ import { WebResource } from "./webResource";
  * Initializes a new instance of the HttpOperationResponse class.
  * @constructor
  */
-export class HttpOperationResponse {
+export interface HttpOperationResponse {
   /**
    * The raw request
    */
   request: WebResource;
+
   /**
-   * The raw response. Please use the response directly when the response body is a ReadableStream.
+   * The HTTP response status (e.g. 200)
    */
-  response: Response;
+  status: number;
+
+  /**
+   * The HTTP response headers.
+   */
+  headers: HttpHeaders;
+
   /**
    * The response body as text (string format)
    */
@@ -27,24 +35,17 @@ export class HttpOperationResponse {
   /**
    * The response body as parsed JSON or XML
    */
-  parsedBody?: { [key: string]: any } | Array<any> | string | number | boolean | null | void;
+  parsedBody?: any;
 
-  constructor(request: WebResource, response: Response) {
-    /**
-     * Reference to the original request object.
-     * [WebResource] object.
-     * @type {object}
-     */
-    this.request = request;
+  /**
+   * The response body as a Blob.
+   * Always undefined in node.js.
+   */
+  blobBody?: (() => Promise<Blob>);
 
-    /**
-     * Reference to the original response object.
-     * [ServerResponse] object.
-     * @type {object}
-     */
-    this.response = response;
-    /* tslint:disable:no-null-keyword */
-    this.bodyAsText = null;
-    this.parsedBody = null;
-  }
+  /**
+   * The response body as a node.js Readable stream.
+   * Always undefined in the browser.
+   */
+  readableStreamBody?: NodeJS.ReadableStream;
 }

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -1,50 +1,39 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { WebResource, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase } from "./webResource";
-import { FetchHttpClient } from "./fetchHttpClient";
-import { HttpClient } from "./httpClient";
-import { HttpOperationResponse } from "./httpOperationResponse";
-import { HttpPipelineLogger } from "./httpPipelineLogger";
-import { HttpPipelineLogLevel } from "./httpPipelineLogLevel";
+export { WebResource, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase } from "./webResource";
+export { FetchHttpClient } from "./fetchHttpClient";
+export { HttpClient } from "./httpClient";
+export { HttpOperationResponse } from "./httpOperationResponse";
+export { HttpPipelineLogger } from "./httpPipelineLogger";
+export { HttpPipelineLogLevel } from "./httpPipelineLogLevel";
+export { RestError } from "./restError";
 export { OperationSpec } from "./operationSpec";
-import { RestError } from "./restError";
-import { ServiceClient, ServiceClientOptions } from "./serviceClient";
-import { Constants } from "./util/constants";
-import { logPolicy } from "./policies/logPolicy";
-import { BaseRequestPolicy, RequestPolicy } from "./policies/requestPolicy";
-import { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
-import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
-import { redirectPolicy } from "./policies/redirectPolicy";
-import { signingPolicy } from "./policies/signingPolicy";
-import { msRestUserAgentPolicy } from "./policies/msRestUserAgentPolicy";
-import {
+export { ServiceClient, ServiceClientOptions } from "./serviceClient";
+export { Constants } from "./util/constants";
+export { logPolicy } from "./policies/logPolicy";
+export { BaseRequestPolicy, RequestPolicy } from "./policies/requestPolicy";
+export { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
+export { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
+export { redirectPolicy } from "./policies/redirectPolicy";
+export { signingPolicy } from "./policies/signingPolicy";
+export { msRestUserAgentPolicy } from "./policies/msRestUserAgentPolicy";
+export {
   BaseMapperType, CompositeMapper, DictionaryMapper, EnumMapper, Mapper,
   MapperConstraints, MapperType, PolymorphicDiscriminator,
   SequenceMapper, Serializer, UrlParameterValue, serializeObject
 } from "./serializer";
-import {
+export {
   stripRequest, stripResponse, delay,
   executePromisesSequentially, generateUuid, encodeUri, ServiceCallback,
   promiseToCallback, promiseToServiceCallback, isValidUuid,
   applyMixins, isNode, stringifyXML, prepareXMLRootList, isDuration
 } from "./util/utils";
-import { URLBuilder, URLQuery } from "./url";
+export { URLBuilder, URLQuery } from "./url";
 
 // Credentials
-import { TokenCredentials } from "./credentials/tokenCredentials";
-import { BasicAuthenticationCredentials } from "./credentials/basicAuthenticationCredentials";
-import { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKeyCredentials";
-import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
-import * as isStream from "is-stream";
-
-export {
-  BaseMapperType, CompositeMapper, DictionaryMapper, EnumMapper, Mapper, MapperConstraints, MapperType, FetchHttpClient,
-  PolymorphicDiscriminator, SequenceMapper, UrlParameterValue, Serializer, serializeObject, HttpClient, HttpPipelineLogger, HttpPipelineLogLevel, TokenCredentials,
-  WebResource, RequestPrepareOptions, HttpMethods, ParameterValue, HttpOperationResponse, ServiceClient, Constants,
-  BasicAuthenticationCredentials, ApiKeyCredentials, ApiKeyCredentialOptions, ServiceClientCredentials, BaseRequestPolicy, logPolicy, ServiceClientOptions, exponentialRetryPolicy,
-  systemErrorRetryPolicy, signingPolicy, msRestUserAgentPolicy, stripRequest, stripResponse, delay, executePromisesSequentially,
-  generateUuid, isValidUuid, encodeUri, RestError, RequestOptionsBase, RequestPolicy, ServiceCallback, promiseToCallback,
-  promiseToServiceCallback, isStream, redirectPolicy, applyMixins, isNode, stringifyXML, prepareXMLRootList, isDuration,
-  URLBuilder, URLQuery
-};
+export { TokenCredentials } from "./credentials/tokenCredentials";
+export { BasicAuthenticationCredentials } from "./credentials/basicAuthenticationCredentials";
+export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKeyCredentials";
+export { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
+export const isStream = require("is-stream");

--- a/lib/policies/exponentialRetryPolicy.ts
+++ b/lib/policies/exponentialRetryPolicy.ts
@@ -111,17 +111,16 @@ export class ExponentialRetryPolicy extends BaseRequestPolicy {
     return retryData;
   }
 
-  async retry(operationResponse: HttpOperationResponse, retryData?: RetryData, err?: RetryError): Promise<HttpOperationResponse> {
+  async retry(response: HttpOperationResponse, retryData?: RetryData, err?: RetryError): Promise<HttpOperationResponse> {
     const self = this;
-    const response = operationResponse.response;
     retryData = self.updateRetryData(retryData, err);
-    if (!utils.objectIsNull(response) && self.shouldRetry(response.status, retryData)) {
+    if (self.shouldRetry(response.status, retryData)) {
       try {
         await utils.delay(retryData.retryInterval);
-        const res: HttpOperationResponse = await this._nextPolicy.sendRequest(operationResponse.request);
+        const res: HttpOperationResponse = await this._nextPolicy.sendRequest(response.request);
         return self.retry(res, retryData, err);
       } catch (err) {
-        return self.retry(operationResponse, retryData, err);
+        return self.retry(response, retryData, err);
       }
     } else {
       if (!utils.objectIsNull(err)) {
@@ -129,7 +128,7 @@ export class ExponentialRetryPolicy extends BaseRequestPolicy {
         err = retryData.error;
         return Promise.reject(err);
       }
-      return Promise.resolve(operationResponse);
+      return Promise.resolve(response);
     }
   }
 

--- a/lib/policies/logPolicy.ts
+++ b/lib/policies/logPolicy.ts
@@ -27,7 +27,7 @@ export class LogPolicy extends BaseRequestPolicy {
 
   public logResponse(response: HttpOperationResponse): Promise<HttpOperationResponse> {
     this.logger(`>> Request: ${JSON.stringify(response.request, undefined, 2)}`);
-    this.logger(`>> Response status code: ${response.response.status}`);
+    this.logger(`>> Response status code: ${response.status}`);
     const responseBody = response.bodyAsText;
     this.logger(`>> Body: ${responseBody}`);
     return Promise.resolve(response);

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -20,14 +20,14 @@ export class RedirectPolicy extends BaseRequestPolicy {
     this.maximumRetries = maximumRetries;
   }
 
-  async handleRedirect(operationResponse: HttpOperationResponse, currentRetries: number): Promise<HttpOperationResponse> {
-    const request = operationResponse.request;
-    const response = operationResponse.response;
-    if (response && response.headers && response.headers.get("location") &&
+  async handleRedirect(response: HttpOperationResponse, currentRetries: number): Promise<HttpOperationResponse> {
+    const request = response.request;
+    const locationHeader = response.headers.get("location");
+    if (locationHeader &&
       (response.status === 300 || response.status === 307 || (response.status === 303 && request.method === "POST")) &&
       (!this.maximumRetries || currentRetries < this.maximumRetries)) {
 
-      request.url = parse(response.headers.get("location")!, parse(request.url)).href;
+      request.url = parse(locationHeader, parse(request.url)).href;
 
       // POST request with Status code 303 should be converted into a
       // redirected GET request if the redirect url is present in the location header
@@ -43,7 +43,7 @@ export class RedirectPolicy extends BaseRequestPolicy {
       }
       return this.handleRedirect(res, currentRetries);
     }
-    return Promise.resolve(operationResponse);
+    return Promise.resolve(response);
   }
 
   public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/lib/policies/rpRegistrationPolicy.ts
+++ b/lib/policies/rpRegistrationPolicy.ts
@@ -22,11 +22,11 @@ export class RPRegistrationPolicy extends BaseRequestPolicy {
     return this.registerIfNeeded(response);
   }
 
-  async registerIfNeeded(operationResponse: HttpOperationResponse): Promise<HttpOperationResponse> {
+  async registerIfNeeded(response: HttpOperationResponse): Promise<HttpOperationResponse> {
     let rpName, urlPrefix;
-    const options = operationResponse.request;
-    if (operationResponse.response.status === 409) {
-      rpName = this.checkRPNotRegisteredError(operationResponse.bodyAsText as string);
+    const options = response.request;
+    if (response.status === 409) {
+      rpName = this.checkRPNotRegisteredError(response.bodyAsText as string);
     }
     if (rpName) {
       urlPrefix = this.extractSubscriptionUrl(options.url);
@@ -52,7 +52,7 @@ export class RPRegistrationPolicy extends BaseRequestPolicy {
         return Promise.resolve(finalRes);
       }
     }
-    return Promise.resolve(operationResponse);
+    return Promise.resolve(response);
   }
 
   /**
@@ -140,13 +140,13 @@ export class RPRegistrationPolicy extends BaseRequestPolicy {
     const reqOptions = this.getRequestEssentials(originalRequest);
     reqOptions.method = "POST";
     reqOptions.url = postUrl;
-    let res: HttpOperationResponse;
+    let response: HttpOperationResponse;
     try {
-      res = await this._nextPolicy.sendRequest(reqOptions);
+      response = await this._nextPolicy.sendRequest(reqOptions);
     } catch (err) {
       return Promise.reject(err);
     }
-    if (res.response.status !== 200) {
+    if (response.status !== 200) {
       return Promise.reject(new Error(`Autoregistration of ${provider} failed. Please try registering manually.`));
     }
     let statusRes = false;

--- a/lib/restError.ts
+++ b/lib/restError.ts
@@ -2,14 +2,15 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { WebResource } from "./webResource";
+import { HttpOperationResponse } from "./msRest";
 
 export class RestError extends Error {
   code?: string;
   statusCode?: number;
   request?: WebResource;
-  response?: Response;
+  response?: HttpOperationResponse;
   body?: any;
-  constructor(message: string, code?: string, statusCode?: number, request?: WebResource, response?: Response, body?: any) {
+  constructor(message: string, code?: string, statusCode?: number, request?: WebResource, response?: HttpOperationResponse, body?: any) {
     super(message);
     this.code = code;
     this.statusCode = statusCode;

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -55,13 +55,13 @@ export function encodeUri(uri: string): string {
  * Returns a stripped version of the Http Response which only contains body,
  * headers and the status.
  *
- * @param {nodeFetch.Response} response - The Http Response
+ * @param {HttpOperationResponse} response - The Http Response
  *
  * @return {object} strippedResponse - The stripped version of Http Response.
  */
-export function stripResponse(response: Response): any {
+export function stripResponse(response: HttpOperationResponse): any {
   const strippedResponse: any = {};
-  strippedResponse.body = response.body;
+  strippedResponse.body = response.bodyAsText;
   strippedResponse.headers = response.headers;
   strippedResponse.status = response.status;
   return strippedResponse;
@@ -199,9 +199,9 @@ export function strEnum<T extends string>(o: Array<T>): {[K in T]: K} {
  * @property {Error|RestError} err         - The error occurred if any, while executing the request; otherwise null
  * @property {TResult} result                 - The deserialized response body if an error did not occur.
  * @property {WebResource}  request           - The raw/actual request sent to the server if an error did not occur.
- * @property {Response} response  - The raw/actual response from the server if an error did not occur.
+ * @property {HttpOperationResponse} response  - The raw/actual response from the server if an error did not occur.
  */
-export interface ServiceCallback<TResult> { (err: Error | RestError, result?: TResult, request?: WebResource, response?: Response): void; }
+export interface ServiceCallback<TResult> { (err: Error | RestError, result?: TResult, request?: WebResource, response?: HttpOperationResponse): void; }
 
 /**
  * Converts a Promise to a callback.
@@ -232,7 +232,7 @@ export function promiseToServiceCallback<T>(promise: Promise<HttpOperationRespon
   }
   return (cb: ServiceCallback<T>): void => {
     promise.then((data: HttpOperationResponse) => {
-      process.nextTick(cb, undefined, data.parsedBody as T, data.request, data.response);
+      process.nextTick(cb, undefined, data.parsedBody as T, data.request, data);
     }, (err: Error) => {
       process.nextTick(cb, err);
     });

--- a/test/shared/logFilterTests.ts
+++ b/test/shared/logFilterTests.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import * as assert from "assert";
-import { Response } from "node-fetch";
 import { LogPolicy } from "../../lib/policies/logPolicy";
 import { HttpOperationResponse } from "../../lib/httpOperationResponse";
 import { WebResource } from "../../lib/webResource";
 import { RequestPolicy, RequestPolicyOptions } from "../../lib/policies/requestPolicy";
+import { HttpHeaders } from "../../lib/httpHeaders";
 
 const emptyRequestPolicy: RequestPolicy = {
   sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -34,8 +34,7 @@ describe("Log filter", () => {
     const logger = (message: string): void => { output += message + "\n"; };
     const lf = new LogPolicy(emptyRequestPolicy, new RequestPolicyOptions(), logger);
     const req = new WebResource("https://foo.com", "PUT", { "a": 1 });
-    const res = new Response();
-    const opRes = new HttpOperationResponse(req, res as any);
+    const opRes: HttpOperationResponse = { request: req, status: 200, headers: new HttpHeaders(), bodyAsText: null };
     lf.logResponse(opRes).then(() => {
       // console.dir(output, { depth: null });
       // console.log(">>>>>>>");


### PR DESCRIPTION
- Pulls HttpHeaders class as-is from httpPipeline branch
- Simplifies msRest.ts because I found out `export { ... } from "other-module"` is a thing

- Is there a reason for HttpOperationResponse itself to be a class type? Seems like maybe not since any HttpClient implementation can implement the interface with their own class type. If you don't agree I can change the interface I have there to be some "properties" type which is used as a constructor argument.

- Thinking of just providing the HttpOperationResponse directly in the generated code in the streaming case. Any apparent reason to do it differently?