### PR TITLE
Add onUpload/DownloadProgress properties and createOperationArguments

### DIFF
--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -103,6 +103,12 @@ export class AxiosHttpClient implements HttpClient {
       bodyType === "function" ? httpRequest.body() :
       httpRequest.body;
 
+    const userUploadProgress = httpRequest.onUploadProgress;
+    const onUploadProgress = userUploadProgress && ((rawEvent: ProgressEvent) => userUploadProgress({ loaded: rawEvent.loaded, total: rawEvent.lengthComputable ? rawEvent.total : undefined }));
+
+    const userDownloadProgress = httpRequest.onDownloadProgress;
+    const onDownloadProgress = userDownloadProgress && ((rawEvent: ProgressEvent) => userDownloadProgress({ loaded: rawEvent.loaded, total: rawEvent.lengthComputable ? rawEvent.total : undefined }));
+
     let res: AxiosResponse;
     try {
       const config: AxiosRequestConfig = {
@@ -116,7 +122,9 @@ export class AxiosHttpClient implements HttpClient {
         // Workaround for https://github.com/axios/axios/issues/1362
         maxContentLength: 1024 * 1024 * 1024 * 10,
         responseType: httpRequest.rawResponse ? (isNode ? "stream" : "blob") : "text",
-        cancelToken
+        cancelToken,
+        onUploadProgress,
+        onDownloadProgress
       };
       res = await axiosClient(config);
     } catch (err) {

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -19,6 +19,8 @@ if (isNode) {
   axiosClient.interceptors.request.use(config => ({ ...config, method: config.method && config.method.toUpperCase() }));
 }
 
+type AxiosProgressFunction = (rawEvent: ProgressEvent) => void;
+
 /**
  * A HttpClient implementation that uses axios to send HTTP requests.
  */
@@ -104,10 +106,12 @@ export class AxiosHttpClient implements HttpClient {
       httpRequest.body;
 
     const userUploadProgress = httpRequest.onUploadProgress;
-    const onUploadProgress = userUploadProgress && ((rawEvent: ProgressEvent) => userUploadProgress({ loaded: rawEvent.loaded, total: rawEvent.lengthComputable ? rawEvent.total : undefined }));
+    const onUploadProgress: AxiosProgressFunction | undefined = userUploadProgress && (rawEvent =>
+      userUploadProgress({ loadedBytes: rawEvent.loaded, totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined }));
 
     const userDownloadProgress = httpRequest.onDownloadProgress;
-    const onDownloadProgress = userDownloadProgress && ((rawEvent: ProgressEvent) => userDownloadProgress({ loaded: rawEvent.loaded, total: rawEvent.lengthComputable ? rawEvent.total : undefined }));
+    const onDownloadProgress: AxiosProgressFunction | undefined = userDownloadProgress && (rawEvent =>
+      userDownloadProgress({ loadedBytes: rawEvent.loaded, totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined }));
 
     let res: AxiosResponse;
     try {

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -11,6 +11,7 @@ export { HttpPipelineLogLevel } from "./httpPipelineLogLevel";
 export { RestError } from "./restError";
 export { OperationSpec } from "./operationSpec";
 export { OperationParameterType } from "./operationParameterType";
+export { OperationArguments, createOperationArguments } from "./operationArguments";
 export { ServiceClient, ServiceClientOptions } from "./serviceClient";
 export { QueryCollectionFormat } from "./queryCollectionFormat";
 export { Constants } from "./util/constants";

--- a/lib/operationArguments.ts
+++ b/lib/operationArguments.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+import { RequestOptionsBase, TransferProgressEvent } from "./webResource";
+
 /**
  * A collection of properties that apply to a single invocation of an operation.
  */
@@ -20,4 +22,30 @@ export interface OperationArguments {
    * The signal which can be used to abort requests.
    */
   abortSignal?: AbortSignal;
+
+  /**
+   * Callback which fires upon upload progress. Only used in the browser.
+   */
+  onUploadProgress?: (progress: TransferProgressEvent) => void;
+
+  /**
+   * Callback which fires upon download progress. Only used in the browser.
+   */
+  onDownloadProgress?: (progress: TransferProgressEvent) => void;
+}
+
+/**
+ * Assigns the properties of a RequestOptions object to an OperationArguments object.
+ * @param args the arguments object to use in the OperatonArguments
+ * @param options the RequestOptions to apply
+ * @return an OperationArguments object
+ */
+export function createOperationArguments(args: { [parameterName: string]: any }, options?: RequestOptionsBase): OperationArguments {
+  return {
+    arguments: args,
+    customHeaders: options && options.customHeaders,
+    abortSignal: options && options.abortSignal,
+    onUploadProgress: options && options.onUploadProgress,
+    onDownloadProgress: options && options.onDownloadProgress,
+  };
 }

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -264,6 +264,14 @@ export class ServiceClient {
       httpRequest.abortSignal = operationArguments.abortSignal;
     }
 
+    if (operationArguments.onUploadProgress) {
+      httpRequest.onUploadProgress = operationArguments.onUploadProgress;
+    }
+
+    if (operationArguments.onDownloadProgress) {
+      httpRequest.onDownloadProgress = operationArguments.onDownloadProgress;
+    }
+
     if (operationSpec.requestBodyName) {
       httpRequest.body = operationArguments.arguments[operationSpec.requestBodyName];
     } else if (operationSpec.formDataParameters && operationSpec.formDataParameters.length > 0) {

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -16,13 +16,13 @@ export type TransferProgressEvent = {
   /**
    * The number of bytes loaded so far.
    */
-  loaded: number,
+  loadedBytes: number,
 
   /**
    * The total number of bytes that will be loaded.
    * If the total number of bytes is unknown, this property will be undefined.
    */
-  total?: number
+  totalBytes?: number
 };
 
 /**

--- a/test/shared/axiosHttpClientTests.ts
+++ b/test/shared/axiosHttpClientTests.ts
@@ -166,4 +166,31 @@ describe("axiosHttpClient", () => {
       }
     }
   });
+
+  it("should report upload and download progress (browser only)", async function() {
+    if (isNode) {
+      this.skip();
+    }
+
+    let uploadNotified = false;
+    let downloadNotified = false;
+
+    const buf = new Uint8Array(1024*1024*1);
+    const request = new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, undefined,
+      ev => {
+        uploadNotified = true;
+        ev.should.not.be.instanceof(ProgressEvent);
+        ev.loaded.should.be.a.Number;
+      },
+      ev => {
+        downloadNotified = true;
+        ev.should.not.be.instanceof(ProgressEvent);
+        ev.loaded.should.be.a.Number;
+      });
+
+    const client = new AxiosHttpClient();
+    await client.sendRequest(request);
+    assert(uploadNotified);
+    assert(downloadNotified);
+  });
 });

--- a/test/shared/axiosHttpClientTests.ts
+++ b/test/shared/axiosHttpClientTests.ts
@@ -180,12 +180,12 @@ describe("axiosHttpClient", () => {
       ev => {
         uploadNotified = true;
         ev.should.not.be.instanceof(ProgressEvent);
-        ev.loaded.should.be.a.Number;
+        ev.loadedBytes.should.be.a.Number;
       },
       ev => {
         downloadNotified = true;
         ev.should.not.be.instanceof(ProgressEvent);
-        ev.loaded.should.be.a.Number;
+        ev.loadedBytes.should.be.a.Number;
       });
 
     const client = new AxiosHttpClient();


### PR DESCRIPTION
Leaving aside the rename/constructor refactor work for now as it's not trivial to unify `constructor()` and `prepare()` and will break people.