### PR TITLE
Use ImportHelpers setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8222,10 +8222,9 @@
       }
     },
     "tslib": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.1.tgz",
-      "integrity": "sha512-avfPS28HmGLLc2o4elcc2EIq2FcH++Yo5YxpBZi9Yw93BCTGFthI4HPE4Rpep6vSYQaK8e69PelM44tPj+RaQg==",
-      "dev": true
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
+      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw=="
     },
     "tslint": {
       "version": "5.10.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "is-buffer": "^2.0.0",
     "isomorphic-tough-cookie": "^0.0.1",
     "isomorphic-xml2js": "^0.0.3",
+    "tslib": "^1.9.2",
     "url-parse": "^1.2.0",
     "uuid": "^3.2.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "declaration": true,
     "declarationDir": "./typings",
+    "importHelpers": true,
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
This brings our bundle from 93.2KB -> 81.4KB. Just seemed so easy to add in that I should just do it. Will do the same with ms-rest-azure-js.