### PR TITLE
Don't run browser tests when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "test:unit": "node ./.scripts/unit",
     "test:server": "ts-node testserver",
     "prepare": "npm run build",
-    "publish-preview": "npm test && shx rm -rf dist/test && node ./.scripts/publish",
+    "publish-preview": "mocha --no-colors && shx rm -rf dist/test && node ./.scripts/publish",
     "local": "node ./.scripts/local.js",
     "preview": "node ./.scripts/preview.js",
     "latest": "node ./.scripts/latest.js"


### PR DESCRIPTION
This fixes our automated publishing. I don't want to get lost in making VSTS run our Chrome tests properly right now, so I'm changing the publish script to only run the nodejs mocha tests.

See https://github.com/Azure/ms-rest-js/pull/108#issuecomment-393639685

We may want to tweak the publish job to email us on failure or something like that.