### PR TITLE
Remove more stuff

### DIFF
--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -122,6 +122,7 @@ export class AxiosHttpClient implements HttpClient {
         data: axiosBody,
         transformResponse: undefined,
         validateStatus: () => true,
+        maxRedirects: 0,
         withCredentials: true,
         // Workaround for https://github.com/axios/axios/issues/1362
         maxContentLength: 1024 * 1024 * 1024 * 10,

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -122,8 +122,6 @@ export class AxiosHttpClient implements HttpClient {
         data: axiosBody,
         transformResponse: undefined,
         validateStatus: () => true,
-        maxRedirects: 0,
-        withCredentials: true,
         // Workaround for https://github.com/axios/axios/issues/1362
         maxContentLength: 1024 * 1024 * 1024 * 10,
         responseType: httpRequest.rawResponse ? (isNode ? "stream" : "blob") : "text",

--- a/lib/policies/msRestUserAgentPolicy.stub.ts
+++ b/lib/policies/msRestUserAgentPolicy.stub.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+export const msRestUserAgentPolicy: any = () => {
+  throw new Error("msRestUserAgentPolicy not supported in browser");
+};

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-import * as parse from "url-parse";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { WebResource } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyCreator, RequestPolicyOptions } from "./requestPolicy";
+import { URLBuilder } from "../url";
 
 export function redirectPolicy(maximumRetries = 20): RequestPolicyCreator {
   return (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
@@ -27,7 +27,9 @@ export class RedirectPolicy extends BaseRequestPolicy {
       (response.status === 300 || response.status === 307 || (response.status === 303 && request.method === "POST")) &&
       (!this.maximumRetries || currentRetries < this.maximumRetries)) {
 
-      request.url = parse(locationHeader, parse(request.url)).href;
+      const builder = URLBuilder.parse(request.url);
+      builder.setPath(locationHeader);
+      request.url = builder.toString();
 
       // POST request with Status code 303 should be converted into a
       // redirected GET request if the redirect url is present in the location header

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import * as xml2js from "isomorphic-xml2js";
-import * as uuid from "uuid";
+import * as uuidv4 from "uuid/v4";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { RestError } from "../restError";
 import { WebResource } from "../webResource";
@@ -132,7 +132,7 @@ export function objectValues(obj: { [key: string]: any; }): any[] {
  * @return {string} RFC4122 v4 UUID.
  */
 export function generateUuid(): string {
-  return uuid.v4();
+  return uuidv4();
 }
 
 /*
@@ -200,9 +200,9 @@ export function promiseToCallback(promise: Promise<any>): Function {
   }
   return (cb: Function): void => {
     promise.then((data: any) => {
-      process.nextTick(cb, undefined, data);
+      cb(undefined, data);
     }, (err: Error) => {
-      process.nextTick(cb, err);
+      cb(err);
     });
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,21 +176,6 @@
         "source-map": "^0.6.1"
       }
     },
-    "@types/url-parse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.1.0.tgz",
-      "integrity": "sha512-R3R19GWiA8YSB8UCs/nDqBZhgvdCae/URs5vE/6oldQ9NGjuXueicXNHmux+BJV67I8y+XBP4kBkCJ6NWGz0Gw==",
-      "dev": true,
-      "requires": {
-        "@types/url-search-params": "*"
-      }
-    },
-    "@types/url-search-params": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@types/url-search-params/-/url-search-params-0.10.1.tgz",
-      "integrity": "sha512-rDNpG5l+DOrfl1yHbuFQT8//0+qAapjIxZWunvNPI5neZ5ZkZrZHCqsg3GxmJo8SfzzBdbmVqYRx7/UFJbPIsg==",
-      "dev": true
-    },
     "@types/uuid": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
@@ -6875,11 +6860,6 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "querystringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
-    },
     "quick-lru": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
@@ -7175,11 +7155,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
-    },
-    "requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resolve": {
       "version": "1.7.1",
@@ -8489,15 +8464,6 @@
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.0.tgz",
       "integrity": "sha1-TTNA6AfTdzvamZH4MFrNzCpmXSo=",
       "dev": true
-    },
-    "url-parse": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-      "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
-      "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
-      }
     },
     "url-parse-lax": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   ],
   "main": "./dist/lib/msRest.js",
   "types": "./typings/lib/msRest.d.ts",
+  "browser": {
+    "./dist/lib/msRest.js": "./es/lib/msRest.js",
+    "./es/lib/policies/msRestUserAgentPolicy.js": "./es/lib/policies/msRestUserAgentPolicy.stub.js"
+  },
   "license": "MIT",
   "dependencies": {
     "@types/express": "^4.11.1",
@@ -75,8 +79,9 @@
     "url": "http://github.com/Azure/ms-rest-js/issues"
   },
   "scripts": {
-    "build": "run-p build:node build:browser",
+    "build": "run-p build:node build:es build:browser",
     "build:node": "tsc",
+    "build:es": "tsc -p tsconfig.es.json",
     "build:browser": "webpack && node node_modules/uglify-es/bin/uglifyjs --source-map -c -m -o msRestBundle.min.js msRestBundle.js",
     "watch:node": "tsc -w",
     "watch:browser": "webpack -w",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "isomorphic-tough-cookie": "^0.0.1",
     "isomorphic-xml2js": "^0.0.3",
     "tslib": "^1.9.2",
-    "url-parse": "^1.2.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {
@@ -46,7 +45,6 @@
     "@types/mocha": "^5.2.0",
     "@types/should": "^8.1.30",
     "@types/tough-cookie": "^2.3.3",
-    "@types/url-parse": "^1.1.0",
     "@types/webpack": "^4.1.3",
     "@types/webpack-dev-middleware": "^2.0.1",
     "abortcontroller-polyfill": "^1.1.9",

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 // parseInt just gives NaN (falsy) for undefined/null
-const port = parseInt(process.env.PORT!) || 3001;
+const port = (typeof process !== "undefined" && parseInt(process.env.PORT!)) || 3001;
 
 /**
  * Base URL for the ms-rest-js testserver.

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "es6"
+    "module": "es6",
+    "outDir": "es"
   }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -31,7 +31,7 @@ const config: webpack.Configuration = {
     tty: false,
     v8: false,
     Buffer: false,
-    process: true,
+    process: false,
     stream: false
   }
 };

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -15,12 +15,16 @@ const config: webpack.Configuration = {
       {
         test: /\.tsx?$/,
         loader: 'ts-loader',
-        exclude: /(node_modules|test)/
+        exclude: /(node_modules|test)/,
+        options: { configFile: path.join(__dirname, './tsconfig.es.json') }
       }
     ]
   },
   resolve: {
-    extensions: [".tsx", ".ts", ".js"]
+    extensions: [".tsx", ".ts", ".js"],
+    alias: {
+      "./policies/msRestUserAgentPolicy": path.resolve(__dirname, "./lib/policies/msRestUserAgentPolicy.stub")
+    }
   },
   node: {
     fs: false,

--- a/webpack.testconfig.ts
+++ b/webpack.testconfig.ts
@@ -18,7 +18,8 @@ const config: webpack.Configuration = {
       {
         test: /\.tsx?$/,
         loader: 'ts-loader',
-        exclude: /(node_modules)/
+        exclude: /(node_modules)/,
+        options: { configFile: path.join(__dirname, './tsconfig.es.json') }
       }
     ]
   },

--- a/webpack.testconfig.ts
+++ b/webpack.testconfig.ts
@@ -34,7 +34,7 @@ const config: webpack.Configuration = {
     tty: false,
     v8: false,
     Buffer: false,
-    process: true,
+    process: false,
     stream: false
   }
 };


### PR DESCRIPTION
- Removes `url-parse` module in favor of our own `URLBuilder` to save a few kBs
  - url-parse is about 3.5 kB while URLBuilder is about 7 kB. Is it accurate @daschult that URLBuilder does stuff that url-parse can't?
- Require specifically `uuid/v4` to save a kB
- Disable `process` polyfill to save a kB
  - Don't know how to help our users do this in their own webpack config, but it's a small thing and they're likely to have other code that depends on the process polyfill, so not sure if it matters
- Replace `msRestUserAgentPolicy.js` with a stub in browser to save a few kBs
  - See the [package-browser-field-spec](https://github.com/defunctzombie/package-browser-field-spec) to understand what I was doing there
- Removes `withCredentials: true` in axios to enable more typical CORS use cases
  - Before, we were trying to send cookies over CORS in order to successfully run autorest.typescript tests in browser. We don't need that any more and `withCredentials: true` was preventing our runtime from communicating with ARM over CORS
- Output es6 in `./es/` folder to get better results from webpack tree shaking. This saves about 10 kB.

Overall, this brings msRestBundle.js from 88.3 kB to 70.1 kB.