### PR TITLE
Support mappers per operation group

### DIFF
--- a/lib/operationSpec.ts
+++ b/lib/operationSpec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { Mapper } from "./serializer";
+import { Mapper, Serializer } from "./serializer";
 import { HttpMethods } from "./webResource";
 import { OperationURLParameter, OperationQueryParameter, OperationParameter } from "./operationParameter";
 
@@ -9,6 +9,11 @@ import { OperationURLParameter, OperationQueryParameter, OperationParameter } fr
  * A specification that defines an operation.
  */
 export interface OperationSpec {
+  /**
+   * The serializer to use in this operation.
+   */
+  serializer: Serializer;
+
   /**
    * The HTTP method that should be used by requests for this operation.
    */

--- a/lib/policies/serializationPolicy.ts
+++ b/lib/policies/serializationPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { OperationSpec } from "../operationSpec";
-import { Mapper, MapperType, Serializer } from "../serializer";
+import { Mapper, MapperType } from "../serializer";
 import * as utils from "../util/utils";
 import { WebResource } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyCreator, RequestPolicyOptions } from "./requestPolicy";
@@ -12,9 +12,9 @@ import { BaseRequestPolicy, RequestPolicy, RequestPolicyCreator, RequestPolicyOp
  * Create a new serialization RequestPolicyCreator that will serialized HTTP request bodies as they
  * pass through the HTTP pipeline.
  */
-export function serializationPolicy(serializer: Serializer): RequestPolicyCreator {
+export function serializationPolicy(): RequestPolicyCreator {
   return (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
-    return new SerializationPolicy(nextPolicy, options, serializer);
+    return new SerializationPolicy(nextPolicy, options);
   };
 }
 
@@ -22,7 +22,7 @@ export function serializationPolicy(serializer: Serializer): RequestPolicyCreato
  * A RequestPolicy that will serialize HTTP request bodies as they pass through the HTTP pipeline.
  */
 export class SerializationPolicy extends BaseRequestPolicy {
-  constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions, private readonly _serializer: Serializer) {
+  constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
   }
 
@@ -49,7 +49,7 @@ export class SerializationPolicy extends BaseRequestPolicy {
       if (bodyMapper) {
         try {
           if (request.body != undefined && operationSpec.requestBodyName) {
-            request.body = this._serializer.serialize(bodyMapper, request.body, operationSpec.requestBodyName);
+            request.body = operationSpec.serializer.serialize(bodyMapper, request.body, operationSpec.requestBodyName);
             if (operationSpec.isXML) {
               if (bodyMapper.type.name === MapperType.Sequence) {
                 request.body = utils.stringifyXML(utils.prepareXMLRootList(request.body, bodyMapper.xmlElementName || bodyMapper.xmlName || bodyMapper.serializedName), { rootName: bodyMapper.xmlName || bodyMapper.serializedName });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/shared/policies/serializationPolicyTests.ts
+++ b/test/shared/policies/serializationPolicyTests.ts
@@ -6,7 +6,6 @@ import { HttpHeaders } from "../../../lib/httpHeaders";
 import { HttpOperationResponse } from "../../../lib/httpOperationResponse";
 import { RequestPolicy, RequestPolicyOptions } from "../../../lib/policies/requestPolicy";
 import { SerializationPolicy } from "../../../lib/policies/serializationPolicy";
-import { Serializer } from "../../../lib/serializer";
 import { WebResource } from "../../../lib/webResource";
 
 describe("serializationPolicy", () => {
@@ -20,10 +19,8 @@ describe("serializationPolicy", () => {
     }
   };
 
-  const serializer = new Serializer();
-
   it(`should not modify a request that has no request body mapper`, async () => {
-    const serializationPolicy = new SerializationPolicy(mockPolicy, new RequestPolicyOptions(), serializer);
+    const serializationPolicy = new SerializationPolicy(mockPolicy, new RequestPolicyOptions());
 
     const request = new WebResource();
     request.body = "hello there!";


### PR DESCRIPTION
The main change here is that each operation group will have its own serializer, so we don't actually put a serializer into the SerializationPolicy. Please let me know what you think about the design and that of the corresponding PR for autorest.typescript.

We should bump the minor version for this.