### PR TITLE
Include es/ folder in package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 !dist/lib/**/*.js
+!es/lib/**/*.js
 !typings/lib/**/*.d.ts
 .vscode/
 .idea/


### PR DESCRIPTION
Needed this line in .npmignore to actually include the es6 build in the package. The only thing that actually gave this away apparently was our bundlesize check failing over in autorest.typescript. Strange.