### PR TITLE
Private functions to closures

### DIFF
--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -5,11 +5,7 @@ import * as utils from "./util/utils";
 import * as base64 from "./util/base64";
 
 export class Serializer {
-  modelMappers?: { [key: string]: any };
-
-  constructor(mappers?: { [key: string]: any }, private isXML?: boolean) {
-    this.modelMappers = mappers;
-  }
+  constructor(public modelMappers?: { [key: string]: any }, public isXML?: boolean) { }
 
   validateConstraints(mapper: Mapper, value: any, objectName: string): void {
     if (mapper.constraints && (value !== null || value !== undefined)) {
@@ -67,313 +63,6 @@ export class Serializer {
     }
   }
 
-  private trimEnd(str: string, ch: string) {
-    let len = str.length;
-    while ((len - 1) >= 0 && str[len - 1] === ch) {
-      --len;
-    }
-    return str.substr(0, len);
-  }
-
-  private bufferToBase64Url(buffer: any): string | undefined {
-    if (!buffer) {
-      return undefined;
-    }
-    if (!(buffer instanceof Uint8Array)) {
-      throw new Error(`Please provide an input of type Uint8Array for converting to Base64Url.`);
-    }
-    // Uint8Array to Base64.
-    const str = base64.encodeByteArray(buffer);
-    // Base64 to Base64Url.
-    return this.trimEnd(str, "=").replace(/\+/g, "-").replace(/\//g, "_");
-  }
-
-  private base64UrlToByteArray(str: string): Uint8Array | undefined {
-    if (!str) {
-      return undefined;
-    }
-    if (str && typeof str.valueOf() !== "string") {
-      throw new Error("Please provide an input of type string for converting to Uint8Array");
-    }
-    // Base64Url to Base64.
-    str = str.replace(/\-/g, "+").replace(/\_/g, "/");
-    // Base64 to Uint8Array.
-    return base64.decodeString(str);
-  }
-
-  private splitSerializeName(prop: string): Array<string> {
-    const classes: Array<string> = [];
-    let partialclass = "";
-    const subwords = prop.split(".");
-
-    for (const item of subwords) {
-      if (item.charAt(item.length - 1) === "\\") {
-        partialclass += item.substr(0, item.length - 1) + ".";
-      } else {
-        partialclass += item;
-        classes.push(partialclass);
-        partialclass = "";
-      }
-    }
-
-    return classes;
-  }
-
-  private dateToUnixTime(d: string | Date): number | undefined {
-    if (!d) {
-      return undefined;
-    }
-
-    if (typeof d.valueOf() === "string") {
-      d = new Date(d as string);
-    }
-    return Math.floor((d as Date).getTime() / 1000);
-  }
-
-  private unixTimeToDate(n: number): Date | undefined {
-    if (!n) {
-      return undefined;
-    }
-    return new Date(n * 1000);
-  }
-
-  private serializeBasicTypes(typeName: string, objectName: string, value: any): any {
-    if (value !== null && value !== undefined) {
-      if (typeName.match(/^Number$/ig) !== null) {
-        if (typeof value !== "number") {
-          throw new Error(`${objectName} with value ${value} must be of type number.`);
-        }
-      } else if (typeName.match(/^String$/ig) !== null) {
-        if (typeof value.valueOf() !== "string") {
-          throw new Error(`${objectName} with value "${value}" must be of type string.`);
-        }
-      } else if (typeName.match(/^Uuid$/ig) !== null) {
-        if (!(typeof value.valueOf() === "string" && utils.isValidUuid(value))) {
-          throw new Error(`${objectName} with value "${value}" must be of type string and a valid uuid.`);
-        }
-      } else if (typeName.match(/^Boolean$/ig) !== null) {
-        if (typeof value !== "boolean") {
-          throw new Error(`${objectName} with value ${value} must be of type boolean.`);
-        }
-      } else if (typeName.match(/^Stream$/ig) !== null) {
-        const objectType = typeof value;
-        if (objectType !== "string" &&
-            objectType !== "function" &&
-            !(value instanceof ArrayBuffer) &&
-            !ArrayBuffer.isView(value) &&
-            !(typeof Blob === "function" && value instanceof Blob)) {
-          throw new Error(`${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, or a function returning NodeJS.ReadableStream.`);
-        }
-      }
-    }
-    return value;
-  }
-
-  private serializeEnumType(objectName: string, allowedValues: Array<any>, value: any): any {
-    if (!allowedValues) {
-      throw new Error(`Please provide a set of allowedValues to validate ${objectName} as an Enum Type.`);
-    }
-    const isPresent = allowedValues.some((item) => {
-      if (typeof item.valueOf() === "string") {
-        return item.toLowerCase() === value.toLowerCase();
-      }
-      return item === value;
-    });
-    if (!isPresent) {
-      throw new Error(`${value} is not a valid value for ${objectName}. The valid values are: ${JSON.stringify(allowedValues)}.`);
-    }
-    return value;
-  }
-
-  private serializeByteArrayType(objectName: string, value: any): any {
-    if (value !== null && value !== undefined) {
-      if (!(value instanceof Uint8Array)) {
-        throw new Error(`${objectName} must be of type Uint8Array.`);
-      }
-      value = base64.encodeByteArray(value);
-    }
-    return value;
-  }
-
-  private serializeBase64UrlType(objectName: string, value: any): any {
-    if (value !== null && value !== undefined) {
-      if (!(value instanceof Uint8Array)) {
-        throw new Error(`${objectName} must be of type Uint8Array.`);
-      }
-      value = this.bufferToBase64Url(value);
-    }
-    return value;
-  }
-
-  private serializeDateTypes(typeName: string, value: any, objectName: string) {
-    if (value !== null && value !== undefined) {
-      if (typeName.match(/^Date$/ig) !== null) {
-        if (!(value instanceof Date ||
-          (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
-          throw new Error(`${objectName} must be an instanceof Date or a string in ISO8601 format.`);
-        }
-        value = (value instanceof Date) ? value.toISOString().substring(0, 10) : new Date(value).toISOString().substring(0, 10);
-      } else if (typeName.match(/^DateTime$/ig) !== null) {
-        if (!(value instanceof Date ||
-          (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
-          throw new Error(`${objectName} must be an instanceof Date or a string in ISO8601 format.`);
-        }
-        value = (value instanceof Date) ? value.toISOString() : new Date(value).toISOString();
-      } else if (typeName.match(/^DateTimeRfc1123$/ig) !== null) {
-        if (!(value instanceof Date ||
-          (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
-          throw new Error(`${objectName} must be an instanceof Date or a string in RFC-1123 format.`);
-        }
-        value = (value instanceof Date) ? value.toUTCString() : new Date(value).toUTCString();
-      } else if (typeName.match(/^UnixTime$/ig) !== null) {
-        if (!(value instanceof Date ||
-          (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
-          throw new Error(`${objectName} must be an instanceof Date or a string in RFC-1123/ISO8601 format ` +
-            `for it to be serialized in UnixTime/Epoch format.`);
-        }
-        value = this.dateToUnixTime(value);
-      } else if (typeName.match(/^TimeSpan$/ig) !== null) {
-        if (!utils.isDuration(value)) {
-          throw new Error(`${objectName} must be a string in ISO 8601 format. Instead was "${value}".`);
-        }
-        value = value;
-      }
-    }
-    return value;
-  }
-
-  private serializeSequenceType(mapper: SequenceMapper, object: any, objectName: string) {
-
-    if (!Array.isArray(object)) {
-      throw new Error(`${objectName} must be of type Array.`);
-    }
-    if (!mapper.type.element || typeof mapper.type.element !== "object") {
-      throw new Error(`element" metadata for an Array must be defined in the ` +
-        `mapper and it must of type "object" in ${objectName}.`);
-    }
-    const tempArray = [];
-    for (let i = 0; i < object.length; i++) {
-      tempArray[i] = this.serialize(mapper.type.element, object[i], objectName);
-    }
-    return tempArray;
-  }
-
-  private serializeDictionaryType(mapper: DictionaryMapper, object: any, objectName: string) {
-
-    if (typeof object !== "object") {
-      throw new Error(`${objectName} must be of type object.`);
-    }
-    if (!mapper.type.value || typeof mapper.type.value !== "object") {
-      throw new Error(`"value" metadata for a Dictionary must be defined in the ` +
-        `mapper and it must of type "object" in ${objectName}.`);
-    }
-    const tempDictionary: { [key: string]: any } = {};
-    for (const key in object) {
-      if (object.hasOwnProperty(key)) {
-        tempDictionary[key] = this.serialize(mapper.type.value, object[key], objectName);
-      }
-    }
-    return tempDictionary;
-  }
-
-  private serializeCompositeType(mapper: CompositeMapper, object: any, objectName: string) {
-    // check for polymorphic discriminator
-    if (mapper.type.polymorphicDiscriminator) {
-      mapper = this.getPolymorphicMapper(mapper, object, objectName, "serialize");
-    }
-
-    const payload: any = {};
-    let modelMapper: CompositeMapper = {
-      required: false,
-      serializedName: "serializedName",
-      type: {
-        name: "Composite",
-        className: "className",
-        modelProperties: {}
-      }
-    };
-    if (object !== null && object !== undefined) {
-      let modelProps = mapper.type.modelProperties;
-      if (!modelProps) {
-        if (!mapper.type.className) {
-          throw new Error(`Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(mapper, undefined, 2)}".`);
-        }
-        // get the mapper if modelProperties of the CompositeType is not present and
-        // then get the modelProperties from it.
-        modelMapper = (this.modelMappers as { [key: string]: any })[mapper.type.className];
-        if (!modelMapper) {
-          throw new Error(`mapper() cannot be null or undefined for model "${mapper.type.className}".`);
-        }
-        modelProps = modelMapper.type.modelProperties;
-        if (!modelProps) {
-          throw new Error(`modelProperties cannot be null or undefined in the ` +
-            `mapper "${JSON.stringify(modelMapper)}" of type "${mapper.type.className}" for object "${objectName}".`);
-        }
-      }
-
-      for (const key of Object.keys(modelProps)) {
-        const propertyMapper = modelProps[key];
-
-        let propName: string | undefined;
-        let parentObject: any = payload;
-        if (this.isXML) {
-          if (propertyMapper.xmlIsWrapped) {
-            propName = propertyMapper.xmlName;
-          } else {
-            propName = propertyMapper.xmlElementName || propertyMapper.xmlName;
-          }
-        } else {
-          const paths = this.splitSerializeName(propertyMapper.serializedName);
-          propName = paths.pop();
-
-          for (const pathName of paths) {
-            const childObject = parentObject[pathName];
-            if ((childObject === null || childObject === undefined) && (object[key] !== null && object[key] !== undefined)) {
-              parentObject[pathName] = {};
-            }
-            parentObject = parentObject[pathName];
-          }
-        }
-
-        // make sure required properties of the CompositeType are present
-        if (propertyMapper.required && !propertyMapper.isConstant) {
-          if (object[key] == undefined) {
-            throw new Error(`${key}" cannot be null or undefined in "${objectName}".`);
-          }
-        }
-        // make sure that readOnly properties are not sent on the wire
-        if (propertyMapper.readOnly) {
-          continue;
-        }
-        // serialize the property if it is present in the provided object instance
-        if (((parentObject !== null && parentObject !== undefined) && (propertyMapper.defaultValue !== null && propertyMapper.defaultValue !== undefined)) ||
-          (object[key] !== null && object[key] !== undefined)) {
-          const propertyObjectName = propertyMapper.serializedName !== ""
-            ? objectName + "." + propertyMapper.serializedName
-            : objectName;
-
-          const serializedValue = this.serialize(propertyMapper, object[key], propertyObjectName);
-
-          if (propName !== null && propName !== undefined) {
-            if (propertyMapper.xmlIsAttribute) {
-              // $ is the key attributes are kept under in xml2js.
-              // This keeps things simple while preventing name collision
-              // with names in user documents.
-              parentObject.$ = parentObject.$ || {};
-              parentObject.$[propName] = serializedValue;
-            } else if (propertyMapper.xmlIsWrapped) {
-              parentObject[propName] = { [propertyMapper.xmlElementName!]: serializedValue };
-            } else {
-              parentObject[propName] = serializedValue;
-            }
-          }
-        }
-      }
-      return payload;
-    }
-    return object;
-  }
-
   /**
    * Serialize the given object based on its metadata defined in the mapper
    *
@@ -414,146 +103,25 @@ export class Serializer {
       if (mapperType.match(/^any$/ig) !== null) {
         payload = object;
       } else if (mapperType.match(/^(Number|String|Boolean|Object|Stream|Uuid)$/ig) !== null) {
-        payload = this.serializeBasicTypes(mapperType, objectName, object);
+        payload = serializeBasicTypes(mapperType, objectName, object);
       } else if (mapperType.match(/^Enum$/ig) !== null) {
         const enumMapper: EnumMapper = mapper as EnumMapper;
-        payload = this.serializeEnumType(objectName, enumMapper.type.allowedValues, object);
+        payload = serializeEnumType(objectName, enumMapper.type.allowedValues, object);
       } else if (mapperType.match(/^(Date|DateTime|TimeSpan|DateTimeRfc1123|UnixTime)$/ig) !== null) {
-        payload = this.serializeDateTypes(mapperType, object, objectName);
+        payload = serializeDateTypes(mapperType, object, objectName);
       } else if (mapperType.match(/^ByteArray$/ig) !== null) {
-        payload = this.serializeByteArrayType(objectName, object);
+        payload = serializeByteArrayType(objectName, object);
       } else if (mapperType.match(/^Base64Url$/ig) !== null) {
-        payload = this.serializeBase64UrlType(objectName, object);
+        payload = serializeBase64UrlType(objectName, object);
       } else if (mapperType.match(/^Sequence$/ig) !== null) {
-        payload = this.serializeSequenceType(mapper as SequenceMapper, object, objectName);
+        payload = serializeSequenceType(this, mapper as SequenceMapper, object, objectName);
       } else if (mapperType.match(/^Dictionary$/ig) !== null) {
-        payload = this.serializeDictionaryType(mapper as DictionaryMapper, object, objectName);
+        payload = serializeDictionaryType(this, mapper as DictionaryMapper, object, objectName);
       } else if (mapperType.match(/^Composite$/ig) !== null) {
-        payload = this.serializeCompositeType(mapper as CompositeMapper, object, objectName);
+        payload = serializeCompositeType(this, mapper as CompositeMapper, object, objectName);
       }
     }
     return payload;
-  }
-
-  private deserializeCompositeType(mapper: CompositeMapper, responseBody: any, objectName: string): any {
-    /*jshint validthis: true */
-    // check for polymorphic discriminator
-    if (mapper.type.polymorphicDiscriminator) {
-      mapper = this.getPolymorphicMapper(mapper, responseBody, objectName, "deserialize");
-    }
-
-    let instance: { [key: string]: any } = {};
-    let modelMapper: Mapper = {
-      required: false,
-      serializedName: "serializedName",
-      type: {
-        name: "Composite"
-      }
-    };
-    responseBody = responseBody || {};
-    let modelProps = mapper.type.modelProperties;
-    if (!modelProps) {
-      if (!mapper.type.className) {
-        throw new Error(`Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(mapper)}"`);
-      }
-      // get the mapper if modelProperties of the CompositeType is not present and
-      // then get the modelProperties from it.
-      modelMapper = (this.modelMappers as { [key: string]: any })[mapper.type.className];
-      if (!modelMapper) {
-        throw new Error(`mapper() cannot be null or undefined for model "${mapper.type.className}"`);
-      }
-      modelProps = (modelMapper as CompositeMapper).type.modelProperties;
-      if (!modelProps) {
-        throw new Error(`modelProperties cannot be null or undefined in the ` +
-          `mapper "${JSON.stringify(modelMapper)}" of type "${mapper.type.className}" for responseBody "${objectName}".`);
-      }
-    }
-
-    for (const key of Object.keys(modelProps)) {
-      const propertyMapper = modelProps[key];
-      let propertyObjectName = objectName;
-      if (propertyMapper.serializedName !== "") {
-        propertyObjectName = objectName + "." + propertyMapper.serializedName;
-      }
-
-      if (this.isXML) {
-        if (propertyMapper.xmlIsAttribute && responseBody.$) {
-          instance[key] = this.deserialize(propertyMapper, responseBody.$[propertyMapper.xmlName!], propertyObjectName);
-        } else {
-          const propertyName = propertyMapper.xmlElementName || propertyMapper.xmlName;
-          let unwrappedProperty = responseBody[propertyName!];
-          if (propertyMapper.xmlIsWrapped) {
-            unwrappedProperty = responseBody[propertyMapper.xmlName!];
-            unwrappedProperty = unwrappedProperty && unwrappedProperty[propertyMapper.xmlElementName!];
-            if (unwrappedProperty === undefined) {
-              // undefined means a wrapped list was empty
-              unwrappedProperty = [];
-            }
-          }
-          instance[key] = this.deserialize(propertyMapper, unwrappedProperty, propertyObjectName);
-        }
-      } else {
-        const paths = this.splitSerializeName(modelProps[key].serializedName);
-        // deserialize the property if it is present in the provided responseBody instance
-        let propertyInstance;
-        let res = responseBody;
-        // traversing the object step by step.
-        for (const item of paths) {
-          if (!res) break;
-          res = res[item];
-        }
-        propertyInstance = res;
-        let serializedValue;
-        // paging
-        if (Array.isArray(responseBody[key]) && modelProps[key].serializedName === "") {
-          propertyInstance = responseBody[key];
-          instance = this.deserialize(propertyMapper, propertyInstance, propertyObjectName);
-        } else if (propertyInstance !== null && propertyInstance !== undefined) {
-          serializedValue = this.deserialize(propertyMapper, propertyInstance, propertyObjectName);
-          instance[key] = serializedValue;
-        }
-      }
-    }
-    return instance;
-  }
-
-  private deserializeDictionaryType(mapper: DictionaryMapper, responseBody: any, objectName: string): any {
-    /*jshint validthis: true */
-    if (!mapper.type.value || typeof mapper.type.value !== "object") {
-      throw new Error(`"value" metadata for a Dictionary must be defined in the ` +
-        `mapper and it must of type "object" in ${objectName}`);
-    }
-    if (responseBody) {
-      const tempDictionary: { [key: string]: any } = {};
-      for (const key in responseBody) {
-        if (responseBody.hasOwnProperty(key)) {
-          tempDictionary[key] = this.deserialize(mapper.type.value, responseBody[key], objectName);
-        }
-      }
-      return tempDictionary;
-    }
-    return responseBody;
-  }
-
-  private deserializeSequenceType(mapper: SequenceMapper, responseBody: any, objectName: string): any {
-    /*jshint validthis: true */
-    if (!mapper.type.element || typeof mapper.type.element !== "object") {
-      throw new Error(`element" metadata for an Array must be defined in the ` +
-        `mapper and it must of type "object" in ${objectName}`);
-    }
-    if (responseBody) {
-      if (!Array.isArray(responseBody)) {
-        // xml2js will interpret a single element array as just the element, so force it to be an array
-        responseBody = [responseBody];
-      }
-
-      const tempArray = [];
-      for (let i = 0; i < responseBody.length; i++) {
-        tempArray[i] = this.deserialize(mapper.type.element, responseBody[i], objectName);
-      }
-      return tempArray;
-    }
-    return responseBody;
   }
 
   /**
@@ -604,17 +172,17 @@ export class Serializer {
     } else if (mapperType.match(/^(Date|DateTime|DateTimeRfc1123)$/ig) !== null) {
       payload = new Date(responseBody);
     } else if (mapperType.match(/^UnixTime$/ig) !== null) {
-      payload = this.unixTimeToDate(responseBody);
+      payload = unixTimeToDate(responseBody);
     } else if (mapperType.match(/^ByteArray$/ig) !== null) {
       payload = base64.decodeString(responseBody);
     } else if (mapperType.match(/^Base64Url$/ig) !== null) {
-      payload = this.base64UrlToByteArray(responseBody);
+      payload = base64UrlToByteArray(responseBody);
     } else if (mapperType.match(/^Sequence$/ig) !== null) {
-      payload = this.deserializeSequenceType(mapper as SequenceMapper, responseBody, objectName);
+      payload = deserializeSequenceType(this, mapper as SequenceMapper, responseBody, objectName);
     } else if (mapperType.match(/^Dictionary$/ig) !== null) {
-      payload = this.deserializeDictionaryType(mapper as DictionaryMapper, responseBody, objectName);
+      payload = deserializeDictionaryType(this, mapper as DictionaryMapper, responseBody, objectName);
     } else if (mapperType.match(/^Composite$/ig) !== null) {
-      payload = this.deserializeCompositeType(mapper as CompositeMapper, responseBody, objectName);
+      payload = deserializeCompositeType(this, mapper as CompositeMapper, responseBody, objectName);
     }
 
     if (mapper.isConstant) {
@@ -623,96 +191,523 @@ export class Serializer {
 
     return payload;
   }
+}
 
-  private getPolymorphicMapper(mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
-
-    // check for polymorphic discriminator
-    // Until version 1.15.1, "polymorphicDiscriminator" in the mapper was a string. This method was not effective when the
-    // polymorphicDiscriminator property had a dot in it"s name. So we have comeup with a desgin where polymorphicDiscriminator
-    // will be an object that contains the clientName (normalized property name, ex: "odatatype") and
-    // the serializedName (ex: "odata.type") (We do not escape the dots with double backslash in this case as it is not required)
-    // Thus when serializing, the user will give us an object which will contain the normalizedProperty hence we will lookup
-    // the clientName of the polmorphicDiscriminator in the mapper and during deserialization from the responseBody we will
-    // lookup the serializedName of the polmorphicDiscriminator in the mapper. This will help us in selecting the correct mapper
-    // for the model that needs to be serializes or deserialized.
-    // We need this routing for backwards compatibility. This will absorb the breaking change in the mapper and allow new versions
-    // of the runtime to work seamlessly with older version (>= 0.17.0-Nightly20161008) of Autorest generated node.js clients.
-    if (mapper.type.polymorphicDiscriminator) {
-      if (typeof mapper.type.polymorphicDiscriminator.valueOf() === "string") {
-        return this.getPolymorphicMapperStringVersion(mapper, object, objectName);
-      } else if (mapper.type.polymorphicDiscriminator instanceof Object) {
-        return this.getPolymorphicMapperObjectVersion(mapper, object, objectName, mode);
-      } else {
-        throw new Error(`The polymorphicDiscriminator for "${objectName}" is neither a string nor an object.`);
-      }
-    }
-    return mapper;
+function trimEnd(str: string, ch: string) {
+  let len = str.length;
+  while ((len - 1) >= 0 && str[len - 1] === ch) {
+    --len;
   }
+  return str.substr(0, len);
+}
 
-  // processes new version of the polymorphicDiscriminator in the mapper.
-  private getPolymorphicMapperObjectVersion(mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
+function bufferToBase64Url(buffer: any): string | undefined {
+  if (!buffer) {
+    return undefined;
+  }
+  if (!(buffer instanceof Uint8Array)) {
+    throw new Error(`Please provide an input of type Uint8Array for converting to Base64Url.`);
+  }
+  // Uint8Array to Base64.
+  const str = base64.encodeByteArray(buffer);
+  // Base64 to Base64Url.
+  return trimEnd(str, "=").replace(/\+/g, "-").replace(/\//g, "_");
+}
 
-    // check for polymorphic discriminator
-    let polymorphicPropertyName = "";
-    if (mode === "serialize") {
-      polymorphicPropertyName = "clientName";
-    } else if (mode === "deserialize") {
-      polymorphicPropertyName = "serializedName";
+function base64UrlToByteArray(str: string): Uint8Array | undefined {
+  if (!str) {
+    return undefined;
+  }
+  if (str && typeof str.valueOf() !== "string") {
+    throw new Error("Please provide an input of type string for converting to Uint8Array");
+  }
+  // Base64Url to Base64.
+  str = str.replace(/\-/g, "+").replace(/\_/g, "/");
+  // Base64 to Uint8Array.
+  return base64.decodeString(str);
+}
+
+function splitSerializeName(prop: string): Array<string> {
+  const classes: Array<string> = [];
+  let partialclass = "";
+  const subwords = prop.split(".");
+
+  for (const item of subwords) {
+    if (item.charAt(item.length - 1) === "\\") {
+      partialclass += item.substr(0, item.length - 1) + ".";
     } else {
-      throw new Error(`The given mode "${mode}" for getting the polymorphic mapper for "${objectName}" is inavlid.`);
+      partialclass += item;
+      classes.push(partialclass);
+      partialclass = "";
     }
-    const discriminatorAsObject: PolymorphicDiscriminator = mapper.type.polymorphicDiscriminator as PolymorphicDiscriminator;
-
-    if (discriminatorAsObject &&
-      discriminatorAsObject[polymorphicPropertyName] !== null &&
-      discriminatorAsObject[polymorphicPropertyName] !== undefined) {
-      if (object === null || object === undefined) {
-        throw new Error(`${objectName}" cannot be null or undefined. ` +
-          `"${discriminatorAsObject[polymorphicPropertyName]}" is the ` +
-          `polmorphicDiscriminator and is a required property.`);
-      }
-      if (object[discriminatorAsObject[polymorphicPropertyName]] === null ||
-        object[discriminatorAsObject[polymorphicPropertyName]] === undefined) {
-        throw new Error(`No discriminator field "${discriminatorAsObject[polymorphicPropertyName]}" was found in "${objectName}".`);
-      }
-      let indexDiscriminator = undefined;
-      if (object[discriminatorAsObject[polymorphicPropertyName]] === mapper.type.uberParent) {
-        indexDiscriminator = object[discriminatorAsObject[polymorphicPropertyName]];
-      } else {
-        indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsObject[polymorphicPropertyName]];
-      }
-      if (this.modelMappers && this.modelMappers.discriminators[indexDiscriminator]) {
-        mapper = this.modelMappers.discriminators[indexDiscriminator];
-      }
-    }
-    return mapper;
   }
 
-  // processes old version of the polymorphicDiscriminator in the mapper.
-  private getPolymorphicMapperStringVersion(mapper: CompositeMapper, object: any, objectName: string): CompositeMapper {
-    // check for polymorphic discriminator
-    const discriminatorAsString: string = mapper.type.polymorphicDiscriminator as string;
-    if (discriminatorAsString !== null && discriminatorAsString !== undefined) {
-      if (object === null || object === undefined) {
-        throw new Error(`${objectName}" cannot be null or undefined. "${discriminatorAsString}" is the ` +
-          `polmorphicDiscriminator and is a required property.`);
+  return classes;
+}
+
+function dateToUnixTime(d: string | Date): number | undefined {
+  if (!d) {
+    return undefined;
+  }
+
+  if (typeof d.valueOf() === "string") {
+    d = new Date(d as string);
+  }
+  return Math.floor((d as Date).getTime() / 1000);
+}
+
+function unixTimeToDate(n: number): Date | undefined {
+  if (!n) {
+    return undefined;
+  }
+  return new Date(n * 1000);
+}
+
+function serializeBasicTypes(typeName: string, objectName: string, value: any): any {
+  if (value !== null && value !== undefined) {
+    if (typeName.match(/^Number$/ig) !== null) {
+      if (typeof value !== "number") {
+        throw new Error(`${objectName} with value ${value} must be of type number.`);
       }
-      if (object[discriminatorAsString] === null || object[discriminatorAsString] === undefined) {
-        throw new Error(`No discriminator field "${discriminatorAsString}" was found in "${objectName}".`);
+    } else if (typeName.match(/^String$/ig) !== null) {
+      if (typeof value.valueOf() !== "string") {
+        throw new Error(`${objectName} with value "${value}" must be of type string.`);
       }
-      let indexDiscriminator = undefined;
-      if (object[discriminatorAsString] === mapper.type.uberParent) {
-        indexDiscriminator = object[discriminatorAsString];
-      } else {
-        indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsString];
+    } else if (typeName.match(/^Uuid$/ig) !== null) {
+      if (!(typeof value.valueOf() === "string" && utils.isValidUuid(value))) {
+        throw new Error(`${objectName} with value "${value}" must be of type string and a valid uuid.`);
       }
-      if (this.modelMappers && this.modelMappers.discriminators[indexDiscriminator]) {
-        mapper = this.modelMappers.discriminators[indexDiscriminator];
+    } else if (typeName.match(/^Boolean$/ig) !== null) {
+      if (typeof value !== "boolean") {
+        throw new Error(`${objectName} with value ${value} must be of type boolean.`);
+      }
+    } else if (typeName.match(/^Stream$/ig) !== null) {
+      const objectType = typeof value;
+      if (objectType !== "string" &&
+          objectType !== "function" &&
+          !(value instanceof ArrayBuffer) &&
+          !ArrayBuffer.isView(value) &&
+          !(typeof Blob === "function" && value instanceof Blob)) {
+        throw new Error(`${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, or a function returning NodeJS.ReadableStream.`);
+      }
+    }
+  }
+  return value;
+}
+
+function serializeEnumType(objectName: string, allowedValues: Array<any>, value: any): any {
+  if (!allowedValues) {
+    throw new Error(`Please provide a set of allowedValues to validate ${objectName} as an Enum Type.`);
+  }
+  const isPresent = allowedValues.some((item) => {
+    if (typeof item.valueOf() === "string") {
+      return item.toLowerCase() === value.toLowerCase();
+    }
+    return item === value;
+  });
+  if (!isPresent) {
+    throw new Error(`${value} is not a valid value for ${objectName}. The valid values are: ${JSON.stringify(allowedValues)}.`);
+  }
+  return value;
+}
+
+function serializeByteArrayType(objectName: string, value: any): any {
+  if (value !== null && value !== undefined) {
+    if (!(value instanceof Uint8Array)) {
+      throw new Error(`${objectName} must be of type Uint8Array.`);
+    }
+    value = base64.encodeByteArray(value);
+  }
+  return value;
+}
+
+function serializeBase64UrlType(objectName: string, value: any): any {
+  if (value !== null && value !== undefined) {
+    if (!(value instanceof Uint8Array)) {
+      throw new Error(`${objectName} must be of type Uint8Array.`);
+    }
+    value = bufferToBase64Url(value);
+  }
+  return value;
+}
+
+function serializeDateTypes(typeName: string, value: any, objectName: string) {
+  if (value != undefined) {
+    if (typeName.match(/^Date$/ig) !== null) {
+      if (!(value instanceof Date ||
+        (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
+        throw new Error(`${objectName} must be an instanceof Date or a string in ISO8601 format.`);
+      }
+      value = (value instanceof Date) ? value.toISOString().substring(0, 10) : new Date(value).toISOString().substring(0, 10);
+    } else if (typeName.match(/^DateTime$/ig) !== null) {
+      if (!(value instanceof Date ||
+        (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
+        throw new Error(`${objectName} must be an instanceof Date or a string in ISO8601 format.`);
+      }
+      value = (value instanceof Date) ? value.toISOString() : new Date(value).toISOString();
+    } else if (typeName.match(/^DateTimeRfc1123$/ig) !== null) {
+      if (!(value instanceof Date ||
+        (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
+        throw new Error(`${objectName} must be an instanceof Date or a string in RFC-1123 format.`);
+      }
+      value = (value instanceof Date) ? value.toUTCString() : new Date(value).toUTCString();
+    } else if (typeName.match(/^UnixTime$/ig) !== null) {
+      if (!(value instanceof Date ||
+        (typeof value.valueOf() === "string" && !isNaN(Date.parse(value))))) {
+        throw new Error(`${objectName} must be an instanceof Date or a string in RFC-1123/ISO8601 format ` +
+          `for it to be serialized in UnixTime/Epoch format.`);
+      }
+      value = dateToUnixTime(value);
+    } else if (typeName.match(/^TimeSpan$/ig) !== null) {
+      if (!utils.isDuration(value)) {
+        throw new Error(`${objectName} must be a string in ISO 8601 format. Instead was "${value}".`);
+      }
+      value = value;
+    }
+  }
+  return value;
+}
+
+function serializeSequenceType(serializer: Serializer, mapper: SequenceMapper, object: any, objectName: string) {
+  if (!Array.isArray(object)) {
+    throw new Error(`${objectName} must be of type Array.`);
+  }
+  if (!mapper.type.element || typeof mapper.type.element !== "object") {
+    throw new Error(`element" metadata for an Array must be defined in the ` +
+      `mapper and it must of type "object" in ${objectName}.`);
+  }
+  const tempArray = [];
+  for (let i = 0; i < object.length; i++) {
+    tempArray[i] = serializer.serialize(mapper.type.element, object[i], objectName);
+  }
+  return tempArray;
+}
+
+function serializeDictionaryType(serializer: Serializer, mapper: DictionaryMapper, object: any, objectName: string) {
+
+  if (typeof object !== "object") {
+    throw new Error(`${objectName} must be of type object.`);
+  }
+  if (!mapper.type.value || typeof mapper.type.value !== "object") {
+    throw new Error(`"value" metadata for a Dictionary must be defined in the ` +
+      `mapper and it must of type "object" in ${objectName}.`);
+  }
+  const tempDictionary: { [key: string]: any } = {};
+  for (const key in object) {
+    if (object.hasOwnProperty(key)) {
+      tempDictionary[key] = serializer.serialize(mapper.type.value, object[key], objectName);
+    }
+  }
+  return tempDictionary;
+}
+
+function serializeCompositeType(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string) {
+  // check for polymorphic discriminator
+  if (mapper.type.polymorphicDiscriminator) {
+    mapper = getPolymorphicMapper(serializer, mapper, object, objectName, "serialize");
+  }
+
+  const payload: any = {};
+  let modelMapper: CompositeMapper = {
+    required: false,
+    serializedName: "serializedName",
+    type: {
+      name: "Composite",
+      className: "className",
+      modelProperties: {}
+    }
+  };
+  if (object !== null && object !== undefined) {
+    let modelProps = mapper.type.modelProperties;
+    if (!modelProps) {
+      if (!mapper.type.className) {
+        throw new Error(`Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(mapper, undefined, 2)}".`);
+      }
+      // get the mapper if modelProperties of the CompositeType is not present and
+      // then get the modelProperties from it.
+      modelMapper = (serializer.modelMappers as { [key: string]: any })[mapper.type.className];
+      if (!modelMapper) {
+        throw new Error(`mapper() cannot be null or undefined for model "${mapper.type.className}".`);
+      }
+      modelProps = modelMapper.type.modelProperties;
+      if (!modelProps) {
+        throw new Error(`modelProperties cannot be null or undefined in the ` +
+          `mapper "${JSON.stringify(modelMapper)}" of type "${mapper.type.className}" for object "${objectName}".`);
       }
     }
 
-    return mapper;
+    for (const key of Object.keys(modelProps)) {
+      const propertyMapper = modelProps[key];
+
+      let propName: string | undefined;
+      let parentObject: any = payload;
+      if (serializer.isXML) {
+        if (propertyMapper.xmlIsWrapped) {
+          propName = propertyMapper.xmlName;
+        } else {
+          propName = propertyMapper.xmlElementName || propertyMapper.xmlName;
+        }
+      } else {
+        const paths = splitSerializeName(propertyMapper.serializedName);
+        propName = paths.pop();
+
+        for (const pathName of paths) {
+          const childObject = parentObject[pathName];
+          if ((childObject === null || childObject === undefined) && (object[key] !== null && object[key] !== undefined)) {
+            parentObject[pathName] = {};
+          }
+          parentObject = parentObject[pathName];
+        }
+      }
+
+      // make sure required properties of the CompositeType are present
+      if (propertyMapper.required && !propertyMapper.isConstant) {
+        if (object[key] == undefined) {
+          throw new Error(`${key}" cannot be null or undefined in "${objectName}".`);
+        }
+      }
+      // make sure that readOnly properties are not sent on the wire
+      if (propertyMapper.readOnly) {
+        continue;
+      }
+      // serialize the property if it is present in the provided object instance
+      if (((parentObject !== null && parentObject !== undefined) && (propertyMapper.defaultValue !== null && propertyMapper.defaultValue !== undefined)) ||
+        (object[key] !== null && object[key] !== undefined)) {
+        const propertyObjectName = propertyMapper.serializedName !== ""
+          ? objectName + "." + propertyMapper.serializedName
+          : objectName;
+
+        const serializedValue = serializer.serialize(propertyMapper, object[key], propertyObjectName);
+
+        if (propName !== null && propName !== undefined) {
+          if (propertyMapper.xmlIsAttribute) {
+            // $ is the key attributes are kept under in xml2js.
+            // This keeps things simple while preventing name collision
+            // with names in user documents.
+            parentObject.$ = parentObject.$ || {};
+            parentObject.$[propName] = serializedValue;
+          } else if (propertyMapper.xmlIsWrapped) {
+            parentObject[propName] = { [propertyMapper.xmlElementName!]: serializedValue };
+          } else {
+            parentObject[propName] = serializedValue;
+          }
+        }
+      }
+    }
+    return payload;
   }
+  return object;
+}
+
+function deserializeCompositeType(serializer: Serializer, mapper: CompositeMapper, responseBody: any, objectName: string): any {
+  /*jshint validthis: true */
+  // check for polymorphic discriminator
+  if (mapper.type.polymorphicDiscriminator) {
+    mapper = getPolymorphicMapper(serializer, mapper, responseBody, objectName, "deserialize");
+  }
+
+  let instance: { [key: string]: any } = {};
+  let modelMapper: Mapper = {
+    required: false,
+    serializedName: "serializedName",
+    type: {
+      name: "Composite"
+    }
+  };
+  responseBody = responseBody || {};
+  let modelProps = mapper.type.modelProperties;
+  if (!modelProps) {
+    if (!mapper.type.className) {
+      throw new Error(`Class name for model "${objectName}" is not provided in the mapper "${JSON.stringify(mapper)}"`);
+    }
+    // get the mapper if modelProperties of the CompositeType is not present and
+    // then get the modelProperties from it.
+    modelMapper = (serializer.modelMappers as { [key: string]: any })[mapper.type.className];
+    if (!modelMapper) {
+      throw new Error(`mapper() cannot be null or undefined for model "${mapper.type.className}"`);
+    }
+    modelProps = (modelMapper as CompositeMapper).type.modelProperties;
+    if (!modelProps) {
+      throw new Error(`modelProperties cannot be null or undefined in the ` +
+        `mapper "${JSON.stringify(modelMapper)}" of type "${mapper.type.className}" for responseBody "${objectName}".`);
+    }
+  }
+
+  for (const key of Object.keys(modelProps)) {
+    const propertyMapper = modelProps[key];
+    let propertyObjectName = objectName;
+    if (propertyMapper.serializedName !== "") {
+      propertyObjectName = objectName + "." + propertyMapper.serializedName;
+    }
+
+    if (serializer.isXML) {
+      if (propertyMapper.xmlIsAttribute && responseBody.$) {
+        instance[key] = serializer.deserialize(propertyMapper, responseBody.$[propertyMapper.xmlName!], propertyObjectName);
+      } else {
+        const propertyName = propertyMapper.xmlElementName || propertyMapper.xmlName;
+        let unwrappedProperty = responseBody[propertyName!];
+        if (propertyMapper.xmlIsWrapped) {
+          unwrappedProperty = responseBody[propertyMapper.xmlName!];
+          unwrappedProperty = unwrappedProperty && unwrappedProperty[propertyMapper.xmlElementName!];
+          if (unwrappedProperty === undefined) {
+            // undefined means a wrapped list was empty
+            unwrappedProperty = [];
+          }
+        }
+        instance[key] = serializer.deserialize(propertyMapper, unwrappedProperty, propertyObjectName);
+      }
+    } else {
+      const paths = splitSerializeName(modelProps[key].serializedName);
+      // deserialize the property if it is present in the provided responseBody instance
+      let propertyInstance;
+      let res = responseBody;
+      // traversing the object step by step.
+      for (const item of paths) {
+        if (!res) break;
+        res = res[item];
+      }
+      propertyInstance = res;
+      let serializedValue;
+      // paging
+      if (Array.isArray(responseBody[key]) && modelProps[key].serializedName === "") {
+        propertyInstance = responseBody[key];
+        instance = serializer.deserialize(propertyMapper, propertyInstance, propertyObjectName);
+      } else if (propertyInstance !== null && propertyInstance !== undefined) {
+        serializedValue = serializer.deserialize(propertyMapper, propertyInstance, propertyObjectName);
+        instance[key] = serializedValue;
+      }
+    }
+  }
+  return instance;
+}
+
+function deserializeDictionaryType(serializer: Serializer, mapper: DictionaryMapper, responseBody: any, objectName: string): any {
+  /*jshint validthis: true */
+  if (!mapper.type.value || typeof mapper.type.value !== "object") {
+    throw new Error(`"value" metadata for a Dictionary must be defined in the ` +
+      `mapper and it must of type "object" in ${objectName}`);
+  }
+  if (responseBody) {
+    const tempDictionary: { [key: string]: any } = {};
+    for (const key in responseBody) {
+      if (responseBody.hasOwnProperty(key)) {
+        tempDictionary[key] = serializer.deserialize(mapper.type.value, responseBody[key], objectName);
+      }
+    }
+    return tempDictionary;
+  }
+  return responseBody;
+}
+
+function deserializeSequenceType(serializer: Serializer, mapper: SequenceMapper, responseBody: any, objectName: string): any {
+  /*jshint validthis: true */
+  if (!mapper.type.element || typeof mapper.type.element !== "object") {
+    throw new Error(`element" metadata for an Array must be defined in the ` +
+      `mapper and it must of type "object" in ${objectName}`);
+  }
+  if (responseBody) {
+    if (!Array.isArray(responseBody)) {
+      // xml2js will interpret a single element array as just the element, so force it to be an array
+      responseBody = [responseBody];
+    }
+
+    const tempArray = [];
+    for (let i = 0; i < responseBody.length; i++) {
+      tempArray[i] = serializer.deserialize(mapper.type.element, responseBody[i], objectName);
+    }
+    return tempArray;
+  }
+  return responseBody;
+}
+
+function getPolymorphicMapper(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
+
+  // check for polymorphic discriminator
+  // Until version 1.15.1, "polymorphicDiscriminator" in the mapper was a string. This method was not effective when the
+  // polymorphicDiscriminator property had a dot in it"s name. So we have comeup with a desgin where polymorphicDiscriminator
+  // will be an object that contains the clientName (normalized property name, ex: "odatatype") and
+  // the serializedName (ex: "odata.type") (We do not escape the dots with double backslash in this case as it is not required)
+  // Thus when serializing, the user will give us an object which will contain the normalizedProperty hence we will lookup
+  // the clientName of the polmorphicDiscriminator in the mapper and during deserialization from the responseBody we will
+  // lookup the serializedName of the polmorphicDiscriminator in the mapper. This will help us in selecting the correct mapper
+  // for the model that needs to be serializes or deserialized.
+  // We need this routing for backwards compatibility. This will absorb the breaking change in the mapper and allow new versions
+  // of the runtime to work seamlessly with older version (>= 0.17.0-Nightly20161008) of Autorest generated node.js clients.
+  if (mapper.type.polymorphicDiscriminator) {
+    if (typeof mapper.type.polymorphicDiscriminator.valueOf() === "string") {
+      return getPolymorphicMapperStringVersion(serializer, mapper, object, objectName);
+    } else if (mapper.type.polymorphicDiscriminator instanceof Object) {
+      return getPolymorphicMapperObjectVersion(serializer, mapper, object, objectName, mode);
+    } else {
+      throw new Error(`The polymorphicDiscriminator for "${objectName}" is neither a string nor an object.`);
+    }
+  }
+  return mapper;
+}
+
+// processes new version of the polymorphicDiscriminator in the mapper.
+function getPolymorphicMapperObjectVersion(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
+
+  // check for polymorphic discriminator
+  let polymorphicPropertyName = "";
+  if (mode === "serialize") {
+    polymorphicPropertyName = "clientName";
+  } else if (mode === "deserialize") {
+    polymorphicPropertyName = "serializedName";
+  } else {
+    throw new Error(`The given mode "${mode}" for getting the polymorphic mapper for "${objectName}" is inavlid.`);
+  }
+  const discriminatorAsObject: PolymorphicDiscriminator = mapper.type.polymorphicDiscriminator as PolymorphicDiscriminator;
+
+  if (discriminatorAsObject &&
+    discriminatorAsObject[polymorphicPropertyName] !== null &&
+    discriminatorAsObject[polymorphicPropertyName] !== undefined) {
+    if (object === null || object === undefined) {
+      throw new Error(`${objectName}" cannot be null or undefined. ` +
+        `"${discriminatorAsObject[polymorphicPropertyName]}" is the ` +
+        `polmorphicDiscriminator and is a required property.`);
+    }
+    if (object[discriminatorAsObject[polymorphicPropertyName]] === null ||
+      object[discriminatorAsObject[polymorphicPropertyName]] === undefined) {
+      throw new Error(`No discriminator field "${discriminatorAsObject[polymorphicPropertyName]}" was found in "${objectName}".`);
+    }
+    let indexDiscriminator = undefined;
+    if (object[discriminatorAsObject[polymorphicPropertyName]] === mapper.type.uberParent) {
+      indexDiscriminator = object[discriminatorAsObject[polymorphicPropertyName]];
+    } else {
+      indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsObject[polymorphicPropertyName]];
+    }
+    if (serializer.modelMappers && serializer.modelMappers.discriminators[indexDiscriminator]) {
+      mapper = serializer.modelMappers.discriminators[indexDiscriminator];
+    }
+  }
+  return mapper;
+}
+
+// processes old version of the polymorphicDiscriminator in the mapper.
+function getPolymorphicMapperStringVersion(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string): CompositeMapper {
+  // check for polymorphic discriminator
+  const discriminatorAsString: string = mapper.type.polymorphicDiscriminator as string;
+  if (discriminatorAsString !== null && discriminatorAsString !== undefined) {
+    if (object === null || object === undefined) {
+      throw new Error(`${objectName}" cannot be null or undefined. "${discriminatorAsString}" is the ` +
+        `polmorphicDiscriminator and is a required property.`);
+    }
+    if (object[discriminatorAsString] === null || object[discriminatorAsString] === undefined) {
+      throw new Error(`No discriminator field "${discriminatorAsString}" was found in "${objectName}".`);
+    }
+    let indexDiscriminator = undefined;
+    if (object[discriminatorAsString] === mapper.type.uberParent) {
+      indexDiscriminator = object[discriminatorAsString];
+    } else {
+      indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsString];
+    }
+    if (serializer.modelMappers && serializer.modelMappers.discriminators[indexDiscriminator]) {
+      mapper = serializer.modelMappers.discriminators[indexDiscriminator];
+    }
+  }
+
+  return mapper;
 }
 
 export interface MapperConstraints {

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -5,7 +5,7 @@ import * as utils from "./util/utils";
 import * as base64 from "./util/base64";
 
 export class Serializer {
-  constructor(public modelMappers?: { [key: string]: any }, public isXML?: boolean) { }
+  constructor(public readonly modelMappers?: { [key: string]: any }, public readonly isXML?: boolean) { }
 
   validateConstraints(mapper: Mapper, value: any, objectName: string): void {
     if (mapper.constraints && (value !== null || value !== undefined)) {


### PR DESCRIPTION
Fixes #128. An ms-rest-azure PR will probably come for AzureServiceClient.

This brings us to 70.5 kB -> 68.2 kB because the minifier is allowed to mangle the names of the module-scoped functions instead of having to preserve the names of private members.

I didn't bother to change UrlBuilder to make `private set()` a module-scoped function because it's a very short name :+1: and it also requires changing the private fields referenced by the function to being public