### PR TITLE
Export RequestPolicyOptions

### DIFF
--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -15,7 +15,7 @@ export { ServiceClient, ServiceClientOptions } from "./serviceClient";
 export { QueryCollectionFormat } from "./queryCollectionFormat";
 export { Constants } from "./util/constants";
 export { logPolicy } from "./policies/logPolicy";
-export { BaseRequestPolicy, RequestPolicy, RequestPolicyCreator } from "./policies/requestPolicy";
+export { BaseRequestPolicy, RequestPolicy, RequestPolicyCreator, RequestPolicyOptions } from "./policies/requestPolicy";
 export { exponentialRetryPolicy } from "./policies/exponentialRetryPolicy";
 export { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
 export { redirectPolicy } from "./policies/redirectPolicy";


### PR DESCRIPTION
We must have forgotten to do this--this prevents external users from making convenient use of BaseRequestPolicy.