### PR TITLE
Use const enums where possible

### DIFF
--- a/lib/queryCollectionFormat.ts
+++ b/lib/queryCollectionFormat.ts
@@ -4,37 +4,10 @@
 /**
  * The format that will be used to join an array of values together for a query parameter value.
  */
-export enum QueryCollectionFormat {
-  Csv,
-  Ssv,
-  Tsv,
-  Pipes,
-  Multi,
-}
-
-/**
- * Get the separator string that will be used to join a sequence of values together in a query
- * parameter value.
- * @param {QueryCollectionFormat} queryCollectionFormat The format to get a string separator for.
- * @returns {string} The separator for the provided format.
- */
-export function getQueryCollectionFormatSeparator(queryCollectionFormat: QueryCollectionFormat): string {
-  let separator: string;
-  switch (queryCollectionFormat) {
-    case QueryCollectionFormat.Csv:
-      separator = ",";
-      break;
-    case QueryCollectionFormat.Pipes:
-      separator = "|";
-      break;
-    case QueryCollectionFormat.Ssv:
-      separator = " ";
-      break;
-    case QueryCollectionFormat.Tsv:
-      separator = "\t";
-      break;
-    default:
-      throw new Error(`No separator specified for QueryCollectionFormat: ${QueryCollectionFormat[queryCollectionFormat]}`);
-  }
-  return separator;
+export const enum QueryCollectionFormat {
+  Csv = ",",
+  Ssv = " ",
+  Tsv = "\t",
+  Pipes = "|",
+  Multi = "Multi",
 }

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -18,7 +18,7 @@ import { rpRegistrationPolicy } from "./policies/rpRegistrationPolicy";
 import { serializationPolicy } from "./policies/serializationPolicy";
 import { signingPolicy } from "./policies/signingPolicy";
 import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
-import { getQueryCollectionFormatSeparator, QueryCollectionFormat } from "./queryCollectionFormat";
+import { QueryCollectionFormat } from "./queryCollectionFormat";
 import { Mapper, Serializer } from "./serializer";
 import { URLBuilder } from "./url";
 import { Constants } from "./util/constants";
@@ -213,8 +213,7 @@ export class ServiceClient {
                   }
                 }
               } else {
-                const queryParameterValueSeparator: string = getQueryCollectionFormatSeparator(queryParameter.collectionFormat);
-                queryParameterValue = queryParameterValue.join(queryParameterValueSeparator);
+                queryParameterValue = queryParameterValue.join(queryParameter.collectionFormat);
               }
             }
             if (!queryParameter.skipEncoding) {

--- a/lib/url.ts
+++ b/lib/url.ts
@@ -64,21 +64,23 @@ export class URLQuery {
         text = text.substring(1);
       }
 
-      const parameterNameState = "parameterName";
-      const parameterValueState = "parameterValue";
-      const invalidateParameterState = "invalidParameter";
+      const enum ParseState {
+        parameterName,
+        parameterValue,
+        invalid
+      }
 
-      let currentState = parameterNameState;
+      let currentState = ParseState.parameterName;
 
       let parameterName = "";
       let parameterValue = "";
       for (let i = 0; i < text.length; ++i) {
         const currentCharacter: string = text[i];
         switch (currentState) {
-          case parameterNameState:
+          case ParseState.parameterName:
             switch (currentCharacter) {
               case "=":
-                currentState = parameterValueState;
+                currentState = ParseState.parameterValue;
                 break;
 
               case "&":
@@ -92,19 +94,19 @@ export class URLQuery {
             }
             break;
 
-          case parameterValueState:
+          case ParseState.parameterValue:
             switch (currentCharacter) {
               case "=":
                 parameterName = "";
                 parameterValue = "";
-                currentState = invalidateParameterState;
+                currentState = ParseState.invalid;
                 break;
 
               case "&":
                 result.set(parameterName, parameterValue);
                 parameterName = "";
                 parameterValue = "";
-                currentState = parameterNameState;
+                currentState = ParseState.parameterName;
                 break;
 
               default:
@@ -113,9 +115,9 @@ export class URLQuery {
             }
             break;
 
-          case invalidateParameterState:
+          case ParseState.invalid:
             if (currentCharacter === "&") {
-              currentState = parameterNameState;
+              currentState = ParseState.parameterName;
             }
             break;
 
@@ -123,7 +125,7 @@ export class URLQuery {
             throw new Error("Unrecognized URLQuery parse state: " + currentState);
         }
       }
-      if (currentState === parameterValueState) {
+      if (currentState === ParseState.parameterValue) {
         result.set(parameterName, parameterValue);
       }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "preserveConstEnums": true,
     "sourceMap": true,
     "newLine": "LF",
     "target": "es5",


### PR DESCRIPTION
Fixes #127

This is not really a must have. This saves about 1 kB in the runtime and saves some space in generated code (based on using e.g. `","` instead of `QueryCollectionFormat.Csv`.

If we do this we have to be careful that we only declare `const enums` which we don't expect JavaScript users to want to access in their own code. Based on that idea, I think `QueryCollectionFormat` is a good candidate for `const` while `HttpPipelineLogLevel` should not be `const`.