### PR TITLE
Make QueryCollectionFormat non-const

### DIFF
--- a/lib/queryCollectionFormat.ts
+++ b/lib/queryCollectionFormat.ts
@@ -4,7 +4,7 @@
 /**
  * The format that will be used to join an array of values together for a query parameter value.
  */
-export const enum QueryCollectionFormat {
+export enum QueryCollectionFormat {
   Csv = ",",
   Ssv = " ",
   Tsv = "\t",


### PR DESCRIPTION
It seems like it's too easy for const enums exposed at the library level to cause runtime errors at the usage site, so I'm reverting the `const` change for this enum. If we are in some position of desperately wanting to shave bytes off our bundles then we can consider changing this to something smaller.