### PR TITLE
Improve type safety of mappers

### DIFF
--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -8,43 +8,55 @@ export class Serializer {
   constructor(public readonly modelMappers?: { [key: string]: any }, public readonly isXML?: boolean) { }
 
   validateConstraints(mapper: Mapper, value: any, objectName: string): void {
-    const constraints = mapper.constraints;
     const failValidation = (constraintName: keyof MapperConstraints, constraintValue: any) => {
       throw new Error(`"${objectName}" with value "${value}" should satisfy the constraint "${constraintName}": ${constraintValue}.`);
     };
-    if (constraints && (value != undefined)) {
-      if (constraints.ExclusiveMaximum != undefined && value >= constraints.ExclusiveMaximum) {
-        failValidation("ExclusiveMaximum", constraints.ExclusiveMaximum);
+    if (mapper.constraints && (value != undefined)) {
+      const {
+        ExclusiveMaximum,
+        ExclusiveMinimum,
+        InclusiveMaximum,
+        InclusiveMinimum,
+        MaxItems,
+        MaxLength,
+        MinItems,
+        MinLength,
+        MultipleOf,
+        Pattern,
+        UniqueItems
+      } = mapper.constraints;
+      if (ExclusiveMaximum != undefined && value >= ExclusiveMaximum) {
+        failValidation("ExclusiveMaximum", ExclusiveMaximum);
       }
-      if (constraints.ExclusiveMinimum != undefined && value <= constraints.ExclusiveMinimum) {
-        failValidation("ExclusiveMinimum", constraints.ExclusiveMinimum);
+      if (ExclusiveMinimum != undefined && value <= ExclusiveMinimum) {
+        failValidation("ExclusiveMinimum", ExclusiveMinimum);
       }
-      if (constraints.InclusiveMaximum != undefined && value > constraints.InclusiveMaximum) {
-        failValidation("InclusiveMaximum", constraints.InclusiveMaximum);
+      if (InclusiveMaximum != undefined && value > InclusiveMaximum) {
+        failValidation("InclusiveMaximum", InclusiveMaximum);
       }
-      if (constraints.InclusiveMinimum != undefined && value < constraints.InclusiveMinimum) {
-        failValidation("InclusiveMinimum", constraints.InclusiveMinimum);
+      if (InclusiveMinimum != undefined && value < InclusiveMinimum) {
+        failValidation("InclusiveMinimum", InclusiveMinimum);
       }
-      if (constraints.MaxItems != undefined && value.length > constraints.MaxItems) {
-        failValidation("MaxItems", constraints.MaxItems);
+      if (MaxItems != undefined && value.length > MaxItems) {
+        failValidation("MaxItems", MaxItems);
       }
-      if (constraints.MaxLength != undefined && value.length > constraints.MaxLength) {
-        failValidation("MaxLength", constraints.MaxLength);
+      if (MaxLength != undefined && value.length > MaxLength) {
+        failValidation("MaxLength", MaxLength);
       }
-      if (constraints.MinItems != undefined && value.length < constraints.MinItems) {
-        failValidation("MinItems", constraints.MinItems);
+      if (MinItems != undefined && value.length < MinItems) {
+        failValidation("MinItems", MinItems);
       }
-      if (constraints.MinLength != undefined && value.length < constraints.MinLength) {
-        failValidation("MinLength", constraints.MinLength);
+      if (MinLength != undefined && value.length < MinLength) {
+        failValidation("MinLength", MinLength);
       }
-      if (constraints.MultipleOf != undefined && value % constraints.MultipleOf !== 0) {
-        failValidation("MultipleOf", constraints.MultipleOf);
+      if (MultipleOf != undefined && value % MultipleOf !== 0) {
+        failValidation("MultipleOf", MultipleOf);
       }
-      if (constraints.Pattern && value.match(constraints.Pattern) === null) {
-        failValidation("Pattern", constraints.Pattern);
+      if (Pattern && value.match(Pattern) === null) {
+        failValidation("Pattern", Pattern);
       }
-      if (constraints.UniqueItems && value.length !== value.filter((item: any, i: number, ar: Array<any>) => ar.indexOf(item) === i).length) {
-        failValidation("UniqueItems", constraints.UniqueItems);
+      if (UniqueItems && value.length !== value.filter((item: any, i: number, ar: Array<any>) => ar.indexOf(item) === i).length) {
+        failValidation("UniqueItems", UniqueItems);
       }
     }
   }

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -545,7 +545,7 @@ function deserializeCompositeType(serializer: Serializer, mapper: CompositeMappe
       const dictionary: any = {};
       for (const headerKey of Object.keys(responseBody)) {
         if (headerKey.startsWith(headerCollectionPrefix)) {
-          dictionary[headerKey.substring(headerCollectionPrefix.length)] = serializer.deserialize(propertyMapper.type.value, responseBody[headerKey], propertyObjectName);
+          dictionary[headerKey.substring(headerCollectionPrefix.length)] = serializer.deserialize((propertyMapper as DictionaryMapper).type.value, responseBody[headerKey], propertyObjectName);
         }
       }
       instance[key] = dictionary;
@@ -735,10 +735,9 @@ export interface MapperConstraints {
 
 export interface BaseMapperType {
   name: string;
-  [key: string]: any;
 }
 
-export interface Mapper {
+export interface BaseMapper {
   xmlName?: string;
   xmlIsAttribute?: boolean;
   xmlElementName?: string;
@@ -752,30 +751,32 @@ export interface Mapper {
   constraints?: MapperConstraints;
 }
 
+export type Mapper = BaseMapper | CompositeMapper | SequenceMapper | DictionaryMapper | EnumMapper;
+
 export interface PolymorphicDiscriminator {
   serializedName: string;
   clientName: string;
   [key: string]: string;
 }
 
-export interface CompositeMapper extends Mapper {
+export interface CompositeMapper extends BaseMapper {
   type: {
     name: "Composite";
     className: string;
-    modelProperties?: { [propertyName: string]: Mapper };
+    modelProperties: { [propertyName: string]: Mapper };
     uberParent?: string;
     polymorphicDiscriminator?: string | PolymorphicDiscriminator;
   };
 }
 
-export interface SequenceMapper extends Mapper {
+export interface SequenceMapper extends BaseMapper {
   type: {
     name: "Sequence";
     element: Mapper;
   };
 }
 
-export interface DictionaryMapper extends Mapper {
+export interface DictionaryMapper extends BaseMapper {
   type: {
     name: "Dictionary";
     value: Mapper;
@@ -783,7 +784,7 @@ export interface DictionaryMapper extends Mapper {
   headerCollectionPrefix?: string;
 }
 
-export interface EnumMapper extends Mapper {
+export interface EnumMapper extends BaseMapper {
   type: {
     name: "Enum";
     allowedValues: Array<any>;

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -19,7 +19,7 @@ import { serializationPolicy } from "./policies/serializationPolicy";
 import { signingPolicy } from "./policies/signingPolicy";
 import { systemErrorRetryPolicy } from "./policies/systemErrorRetryPolicy";
 import { QueryCollectionFormat } from "./queryCollectionFormat";
-import { Mapper, Serializer, DictionaryMapper } from "./serializer";
+import { Mapper, Serializer, DictionaryMapper, CompositeMapper } from "./serializer";
 import { URLBuilder } from "./url";
 import { Constants } from "./util/constants";
 import * as utils from "./util/utils";
@@ -359,7 +359,7 @@ function getOperationArgumentValueFromParameterPath(operationArguments: Operatio
       }
     } else {
       for (const propertyName in parameterPath) {
-        const propertyMapper: Mapper = parameterMapper.type.modelProperties[propertyName];
+        const propertyMapper: Mapper = (parameterMapper as CompositeMapper).type.modelProperties[propertyName];
         const propertyPath: ParameterPath = parameterPath[propertyName];
         const propertyValue: any = getOperationArgumentValueFromParameterPath(operationArguments, propertyPath, propertyMapper, serializer);
         // Serialize just for validation purposes.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
This leverages the tagged unions feature to improve the type safety and maintainability of the Mapper interfaces. It solves an issue where the new headerCollectionPrefix failed to type check, and removes the `[key: string]: any` index signature that made us work around variance in the `type` property of various mappers by essentially not type checking them.