### PR TITLE
Update isomorphic-xml2js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -209,10 +209,11 @@
       }
     },
     "@types/xml2js": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.2.tgz",
-      "integrity": "sha512-8aKUBSj3oGcnuiBmDLm3BIk09RYg01mz9HlQ2u4aS17oJ25DxjQrEUVGFSBVNOfM45pQW4OjcBPplq6r/exJdA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
+      "integrity": "sha512-Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==",
       "requires": {
+        "@types/events": "*",
         "@types/node": "*"
       }
     },
@@ -4966,9 +4967,9 @@
       }
     },
     "isomorphic-xml2js": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/isomorphic-xml2js/-/isomorphic-xml2js-0.0.3.tgz",
-      "integrity": "sha512-t86X20d5kcxKHD6iTItHpyXIG9qWAlGLnk4sejrqCyP64L7peSmHE9Xxcpg5WVOY4H2J+TBWuJ7vMlgc/Kov9Q==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/isomorphic-xml2js/-/isomorphic-xml2js-0.1.3.tgz",
+      "integrity": "sha512-dIkT2U9ritKVWF/HfHfGwm5tTnlMnknYsv7l12oJlQQgOV2CNV65pX+FHy6HFL9YP8q0JcrlNQAFRJIN2agUmQ==",
       "requires": {
         "@types/xml2js": "^0.4.2",
         "xml2js": "^0.4.19"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "axios": "^0.18.0",
     "form-data": "^2.3.2",
     "isomorphic-tough-cookie": "^0.0.1",
-    "isomorphic-xml2js": "^0.0.3",
+    "isomorphic-xml2js": "^0.1.3",
     "tslib": "^1.9.2",
     "uuid": "^3.2.1"
   },


### PR DESCRIPTION
Fixes #145. I figured the ^0.0.3 version range would include 0.1.3, but maybe they actually have it special cased for major version 0?