### PR TITLE
Use XhrHttpClient in browser

### DIFF
--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -43,22 +43,20 @@ export class AxiosHttpClient implements HttpClient {
           requestForm.append(key, value);
         }
       };
-      for (const formKey in formData) {
-        if (formData.hasOwnProperty(formKey)) {
-          const formValue = formData[formKey];
-          if (formValue instanceof Array) {
-            for (let j = 0; j < formValue.length; j++) {
-              appendFormValue(formKey, formValue[j]);
-            }
-          } else {
-            appendFormValue(formKey, formValue);
+      for (const formKey of Object.keys(formData)) {
+        const formValue = formData[formKey];
+        if (Array.isArray(formValue)) {
+          for (let j = 0; j < formValue.length; j++) {
+            appendFormValue(formKey, formValue[j]);
           }
+        } else {
+          appendFormValue(formKey, formValue);
         }
       }
 
       httpRequest.body = requestForm;
       httpRequest.formData = undefined;
-      const contentType: string | undefined = httpRequest.headers && httpRequest.headers.get("Content-Type");
+      const contentType = httpRequest.headers.get("Content-Type");
       if (contentType && contentType.indexOf("multipart/form-data") !== -1) {
         if (typeof requestForm.getBoundary === "function") {
           httpRequest.headers.set("Content-Type", `multipart/form-data; boundary=${requestForm.getBoundary()}`);

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -18,8 +18,6 @@ if (isNode) {
   axiosClient.interceptors.request.use(config => ({ ...config, method: config.method && config.method.toUpperCase() }));
 }
 
-type AxiosProgressFunction = (rawEvent: ProgressEvent) => void;
-
 /**
  * A HttpClient implementation that uses axios to send HTTP requests.
  */
@@ -104,14 +102,6 @@ export class AxiosHttpClient implements HttpClient {
       bodyType === "function" ? httpRequest.body() :
       httpRequest.body;
 
-    const userUploadProgress = httpRequest.onUploadProgress;
-    const onUploadProgress: AxiosProgressFunction | undefined = userUploadProgress && (rawEvent =>
-      userUploadProgress({ loadedBytes: rawEvent.loaded, totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined }));
-
-    const userDownloadProgress = httpRequest.onDownloadProgress;
-    const onDownloadProgress: AxiosProgressFunction | undefined = userDownloadProgress && (rawEvent =>
-      userDownloadProgress({ loadedBytes: rawEvent.loaded, totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined }));
-
     let res: AxiosResponse;
     try {
       const config: AxiosRequestConfig = {
@@ -124,9 +114,7 @@ export class AxiosHttpClient implements HttpClient {
         // Workaround for https://github.com/axios/axios/issues/1362
         maxContentLength: 1024 * 1024 * 1024 * 10,
         responseType: httpRequest.rawResponse ? (isNode ? "stream" : "blob") : "text",
-        cancelToken,
-        onUploadProgress,
-        onDownloadProgress
+        cancelToken
       };
       res = await axiosClient(config);
     } catch (err) {

--- a/lib/defaultHttpClient.browser.ts
+++ b/lib/defaultHttpClient.browser.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+export { XhrHttpClient as DefaultHttpClient } from "./xhrHttpClient";

--- a/lib/defaultHttpClient.ts
+++ b/lib/defaultHttpClient.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+export { AxiosHttpClient as DefaultHttpClient } from "./axiosHttpClient";

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase } from "./webResource";
-export { AxiosHttpClient } from "./axiosHttpClient";
+export { DefaultHttpClient } from "./defaultHttpClient";
 export { HttpClient } from "./httpClient";
 export { HttpHeaders } from "./httpHeaders";
 export { HttpOperationResponse } from "./httpOperationResponse";

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { AxiosHttpClient } from "./axiosHttpClient";
+import { DefaultHttpClient } from "./defaultHttpClient";
 import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 import { HttpClient } from "./httpClient";
 import { HttpOperationResponse } from "./httpOperationResponse";
@@ -119,7 +119,7 @@ export class ServiceClient {
       // do nothing
     }
 
-    this._httpClient = options.httpClient || new AxiosHttpClient();
+    this._httpClient = options.httpClient || new DefaultHttpClient();
     this._requestPolicyOptions = new RequestPolicyOptions(options.httpPipelineLogger);
 
     this._requestPolicyCreators = options.requestPolicyCreators || createDefaultRequestPolicyCreators(credentials, options, this.userAgentInfo.value);

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { HttpClient } from "./httpClient";
+import { HttpHeaders } from "./httpHeaders";
+import { WebResource } from './webResource';
+import { HttpOperationResponse } from './httpOperationResponse';
+
+/**
+ * A HttpClient implementation that uses XMLHttpRequest to send HTTP requests.
+ */
+export class XhrHttpClient implements HttpClient {
+  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+    const xhr = new XMLHttpRequest();
+    xhr.responseType = request.rawResponse ? "blob" : "text";
+    for (const header of request.headers.headersArray()) {
+      xhr.setRequestHeader(header.name, header.value);
+    }
+
+    if (request.rawResponse) {
+      return new Promise((resolve, reject) => {
+        xhr.addEventListener("readystatechange", () => {
+          // Resolves when body is finished loading
+          const bodyPromise = new Promise<Blob>((resolve, reject) => {
+            xhr.addEventListener("load", () => {
+              resolve(xhr.response);
+            });
+            xhr.addEventListener("error", reject);
+          });
+
+          // Resolve as soon as headers are loaded
+          if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
+            resolve({
+              request,
+              status: xhr.status,
+              headers: parseHeaders(xhr),
+              blobBody: () => bodyPromise
+            });
+          }
+        });
+        xhr.addEventListener("error", reject);
+      });
+    }
+
+    return new Promise(function(resolve, reject) {
+      xhr.addEventListener("load", () => resolve({
+        request,
+        status: xhr.status,
+        headers: parseHeaders(xhr),
+        bodyAsText: xhr.responseText
+      }))
+      xhr.addEventListener("error", reject);
+    });
+  }
+}
+
+function parseHeaders(xhr: XMLHttpRequest) {
+  const responseHeaders = new HttpHeaders();
+  const headerLines = xhr.getAllResponseHeaders().trim().split(/[\r\n]+/);
+  for (const line of headerLines) {
+    const parts = line.split(': ');
+    const headerName = parts.shift()!;
+    const headerValue = parts.join(': ');
+    responseHeaders.set(headerName, headerValue);
+  }
+  return responseHeaders;
+}

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -14,7 +14,7 @@ export class XhrHttpClient implements HttpClient {
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
     const xhr = new XMLHttpRequest();
 
-    const { abortSignal, onUploadProgress, onDownloadProgress } = request;
+    const abortSignal = request.abortSignal;
     if (abortSignal) {
       const listener = () => {
         xhr.abort();
@@ -27,8 +27,8 @@ export class XhrHttpClient implements HttpClient {
       });
     }
 
-    addProgressListener(xhr.upload, onUploadProgress);
-    addProgressListener(xhr, onDownloadProgress);
+    addProgressListener(xhr.upload, request.onUploadProgress);
+    addProgressListener(xhr, request.onDownloadProgress);
 
     if (request.formData) {
       const formData = request.formData;

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -3,9 +3,9 @@
 
 import { HttpClient } from "./httpClient";
 import { HttpHeaders } from "./httpHeaders";
-import { WebResource, TransferProgressEvent } from './webResource';
-import { HttpOperationResponse } from './httpOperationResponse';
-import { RestError } from './restError';
+import { WebResource, TransferProgressEvent } from "./webResource";
+import { HttpOperationResponse } from "./httpOperationResponse";
+import { RestError } from "./restError";
 
 /**
  * A HttpClient implementation that uses XMLHttpRequest to send HTTP requests.
@@ -95,7 +95,7 @@ export class XhrHttpClient implements HttpClient {
           status: xhr.status,
           headers: parseHeaders(xhr),
           bodyAsText: xhr.responseText
-        }))
+        }));
         rejectOnTerminalEvent(request, xhr, reject);
       });
     }
@@ -115,9 +115,9 @@ function parseHeaders(xhr: XMLHttpRequest) {
   const responseHeaders = new HttpHeaders();
   const headerLines = xhr.getAllResponseHeaders().trim().split(/[\r\n]+/);
   for (const line of headerLines) {
-    const parts = line.split(': ');
+    const parts = line.split(": ");
     const headerName = parts.shift()!;
-    const headerValue = parts.join(': ');
+    const headerValue = parts.join(": ");
     responseHeaders.set(headerName, headerValue);
   }
   return responseHeaders;

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -70,16 +70,14 @@ export class XhrHttpClient implements HttpClient {
     if (request.rawResponse) {
       return new Promise((resolve, reject) => {
         xhr.addEventListener("readystatechange", () => {
-          // Resolves when body is finished loading
-          const bodyPromise = new Promise<Blob>((resolve, reject) => {
-            xhr.addEventListener("load", () => {
-              resolve(xhr.response);
-            });
-            rejectOnTerminalEvent(request, xhr, reject);
-          });
-
           // Resolve as soon as headers are loaded
           if (xhr.readyState === XMLHttpRequest.HEADERS_RECEIVED) {
+            const bodyPromise = new Promise<Blob>((resolve, reject) => {
+              xhr.addEventListener("load", () => {
+                resolve(xhr.response);
+              });
+              rejectOnTerminalEvent(request, xhr, reject);
+            });
             resolve({
               request,
               status: xhr.status,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "browser": {
     "./dist/lib/msRest.js": "./es/lib/msRest.js",
     "./es/lib/policies/msRestUserAgentPolicy.js": "./es/lib/policies/msRestUserAgentPolicy.stub.js",
-    "./es/lib/util/base64.js": "./es/lib/util/base64.browser.js"
+    "./es/lib/util/base64.js": "./es/lib/util/base64.browser.js",
+    "./es/lib/defaultHttpClient.js": "./es/lib/defaultHttpClient.browser.js"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/shared/axiosHttpClientTests.ts
+++ b/test/shared/axiosHttpClientTests.ts
@@ -177,32 +177,4 @@ describe("axiosHttpClient", () => {
     assert(uploadNotified);
     assert(downloadNotified);
   });
-
-  it("should parse a JSON response body", async function() {
-    const request = new WebResource(`${baseURL}/json`);
-    const client = new AxiosHttpClient();
-    const response = await client.sendRequest(request);
-    assert.deepStrictEqual(response.parsedBody, [123,456,789]);
-  });
-
-  it("should parse a JSON response body with a charset specified in Content-Type", async function() {
-    const request = new WebResource(`${baseURL}/json-charset`);
-    const client = new AxiosHttpClient();
-    const response = await client.sendRequest(request);
-    assert.deepStrictEqual(response.parsedBody, [123,456,789]);
-  });
-
-  it("should parse a JSON response body with an uppercase Content-Type", async function() {
-    const request = new WebResource(`${baseURL}/json-uppercase-content-type`);
-    const client = new AxiosHttpClient();
-    const response = await client.sendRequest(request);
-    assert.deepStrictEqual(response.parsedBody, [123,456,789]);
-  });
-
-  it("should parse a JSON response body with a missing Content-Type", async function() {
-    const request = new WebResource(`${baseURL}/json-no-content-type`);
-    const client = new AxiosHttpClient();
-    const response = await client.sendRequest(request);
-    assert.deepStrictEqual(response.parsedBody, [123,456,789]);
-  });
 });

--- a/test/shared/defaultHttpClientTests.ts
+++ b/test/shared/defaultHttpClientTests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 import * as assert from "assert";
 import * as should from "should";
-import { AxiosHttpClient } from "../../lib/axiosHttpClient";
+import { DefaultHttpClient } from "../../lib/defaultHttpClient";
 import { isNode } from "../../lib/util/utils";
 import { WebResource } from "../../lib/webResource";
 import { baseURL } from "../testUtils";
@@ -18,10 +18,10 @@ function getAbortController(): AbortController {
   return controller;
 }
 
-describe("axiosHttpClient", () => {
+describe("defaultHttpClient", () => {
   it("should send HTTP requests", async () => {
     const request = new WebResource(`${baseURL}/example-index.html`, "GET");
-    const httpClient = new AxiosHttpClient();
+    const httpClient = new DefaultHttpClient();
 
     const response = await httpClient.sendRequest(request);
     assert.deepStrictEqual(response.request, request);
@@ -90,7 +90,7 @@ describe("axiosHttpClient", () => {
 
   it("should return a response instead of throwing for awaited 404", async () => {
     const request = new WebResource(`${baseURL}/nonexistent`, "GET");
-    const httpClient = new AxiosHttpClient();
+    const httpClient = new DefaultHttpClient();
 
     const response = await httpClient.sendRequest(request);
     assert(response);
@@ -99,7 +99,7 @@ describe("axiosHttpClient", () => {
   it("should allow canceling requests", async function () {
     const controller = getAbortController();
     const request = new WebResource(`${baseURL}/fileupload`, "POST", new Uint8Array(1024 * 1024 * 10), undefined, undefined, true, controller.signal);
-    const client = new AxiosHttpClient();
+    const client = new DefaultHttpClient();
     const promise = client.sendRequest(request);
     controller.abort();
     try {
@@ -116,7 +116,7 @@ describe("axiosHttpClient", () => {
       this.skip();
     }
 
-    const client = new AxiosHttpClient();
+    const client = new DefaultHttpClient();
 
     const request1 = new WebResource(`${baseURL}/set-cookie`);
     await client.sendRequest(request1);
@@ -137,7 +137,7 @@ describe("axiosHttpClient", () => {
       new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, controller.signal),
       new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, controller.signal)
     ];
-    const client = new AxiosHttpClient();
+    const client = new DefaultHttpClient();
     const promises = requests.map(r => client.sendRequest(r));
     controller.abort();
     // Ensure each promise is individually rejected
@@ -172,7 +172,7 @@ describe("axiosHttpClient", () => {
         ev.loadedBytes.should.be.a.Number;
       });
 
-    const client = new AxiosHttpClient();
+    const client = new DefaultHttpClient();
     await client.sendRequest(request);
     assert(uploadNotified);
     assert(downloadNotified);

--- a/test/shared/defaultHttpClientTests.ts
+++ b/test/shared/defaultHttpClientTests.ts
@@ -175,7 +175,7 @@ describe("defaultHttpClient", () => {
     const client = new DefaultHttpClient();
     const response = await client.sendRequest(request);
     if (response.blobBody) {
-      await response.blobBody;
+      await response.blobBody();
     }
     assert(uploadNotified);
     assert(downloadNotified);

--- a/test/shared/defaultHttpClientTests.ts
+++ b/test/shared/defaultHttpClientTests.ts
@@ -173,7 +173,10 @@ describe("defaultHttpClient", () => {
       });
 
     const client = new DefaultHttpClient();
-    await client.sendRequest(request);
+    const response = await client.sendRequest(request);
+    if (response.blobBody) {
+      await response.blobBody;
+    }
     assert(uploadNotified);
     assert(downloadNotified);
   });

--- a/testserver/index.ts
+++ b/testserver/index.ts
@@ -30,30 +30,6 @@ app.get("/cookie", function(req, res) {
     res.end();
 });
 
-app.get("/json", function(req, res) {
-    res.setHeader("Content-Type", "application/json");
-    res.end("[123, 456, 789]");
-});
-
-app.get("/json-charset", function(req, res) {
-    res.setHeader("Content-Type", "application/json;charset=UTF-8");
-    res.end("[123, 456, 789]");
-});
-
-app.get("/json-uppercase-content-type", function(req, res) {
-    res.setHeader("Content-Type", "APPLICATION/JSON");
-    res.end("[123, 456, 789]");
-});
-
-app.get("/json-no-content-type", function(req, res) {
-    res.end("[123, 456, 789]");
-});
-
-app.get("/json-charset", function(req, res) {
-    res.setHeader("Content-Type", "application/json;charset=UTF-8");
-    res.end("[123, 456, 789]");
-});
-
 app.listen(port, function() {
     console.log(`ms-rest-js testserver listening on port ${port}...`);
 });

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,7 +11,8 @@ const config: webpack.Configuration = {
     library: 'msRest'
   },
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/(\.).+util\/base64/, path.resolve(__dirname, "./lib/util/base64.browser.ts"))
+    new webpack.NormalModuleReplacementPlugin(/(\.).+util\/base64/, path.resolve(__dirname, "./lib/util/base64.browser.ts")),
+    new webpack.NormalModuleReplacementPlugin(/(\.).+defaultHttpClient/, path.resolve(__dirname, "./lib/defaultHttpClient.browser.ts"))
   ],
   module: {
     rules: [

--- a/webpack.testconfig.ts
+++ b/webpack.testconfig.ts
@@ -14,7 +14,8 @@ const config: webpack.Configuration = {
     path: __dirname
   },
   plugins: [
-    new webpack.NormalModuleReplacementPlugin(/(\.).+util\/base64/, path.resolve(__dirname, "./lib/util/base64.browser.ts"))
+    new webpack.NormalModuleReplacementPlugin(/(\.).+util\/base64/, path.resolve(__dirname, "./lib/util/base64.browser.ts")),
+    new webpack.NormalModuleReplacementPlugin(/(\.).+defaultHttpClient/, path.resolve(__dirname, "./lib/defaultHttpClient.browser.ts"))
   ],
   module: {
     rules: [


### PR DESCRIPTION
Fixes #138 by moving JSON/XML parsing to the serializationPolicy. This should also make possible to add variants of serializationPolicy which handle either only JSON or both JSON and XML, which should save our JSON-only users another 6 kB.

This brings our bundle size from 67 kB -> 53.5 kB.