### PR TITLE
Allow operation headers and custom headers to override contentType

### DIFF
--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -218,6 +218,10 @@ export class ServiceClient {
       }
       httpRequest.url = requestUrl.toString();
 
+      if (operationSpec.contentType) {
+        httpRequest.headers.set("Content-Type", operationSpec.contentType);
+      }
+
       if (operationSpec.headerParameters) {
         for (const headerParameter of operationSpec.headerParameters) {
           let headerValue: any = getOperationArgumentValueFromParameter(operationArguments, headerParameter, operationSpec.serializer);
@@ -233,10 +237,6 @@ export class ServiceClient {
             }
           }
         }
-      }
-
-      if (operationSpec.contentType) {
-        httpRequest.headers.set("Content-Type", operationSpec.contentType);
       }
 
       if (operationArguments.customHeaders) {


### PR DESCRIPTION
This fixes the broken test in Azure/autorest.typescript#181

So now, we basically have the following precedence, where higher is.. well, higher:

1. contentType mapper property
2. operation header parameter
3. custom header