### PR TITLE
Make OperationSpec.baseUrl an optional property for moving OperationSpecs into module/file scope

### DIFF
--- a/lib/operationSpec.ts
+++ b/lib/operationSpec.ts
@@ -22,9 +22,10 @@ export interface OperationSpec {
 
   /**
    * The URL that was provided in the service's specification. This will still have all of the URL
-   * template variables in it.
+   * template variables in it. If this is not provided when the OperationSpec is created, then it
+   * will be populated by a "baseUri" property on the ServiceClient.
    */
-  baseUrl: string;
+  baseUrl?: string;
 
   /**
    * The fixed path for this operation's URL. This will still have all of the URL template variables

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -76,6 +76,12 @@ export interface ServiceClientOptions {
  */
 export class ServiceClient {
   /**
+   * If specified, this is the base URI that requests will be made against for this ServiceClient.
+   * If it is not specified, then all OperationSpecs must contain a baseUrl property.
+   */
+  protected baseUri?: string;
+
+  /**
    * The string to be appended to the User-Agent header while sending the request.
    * This will be applicable only for node.js environment as the fetch library in browser does not allow setting custom UA.
    * @property {Array<string>} value - An array of string that need to be appended to the User-Agent request header.
@@ -178,7 +184,7 @@ export class ServiceClient {
     let result: Promise<HttpOperationResponse>;
     try {
       if (operationSpec.baseUrl == undefined) {
-        operationSpec.baseUrl = (this as any).baseUri;
+        operationSpec.baseUrl = this.baseUri;
         if (!operationSpec.baseUrl) {
           throw new Error("If operationSpec.baseUrl is not specified, then the ServiceClient must have a baseUri string property that contains the base URL to use.");
         }

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -177,6 +177,13 @@ export class ServiceClient {
 
     let result: Promise<HttpOperationResponse>;
     try {
+      if (operationSpec.baseUrl == undefined) {
+        operationSpec.baseUrl = (this as any).baseUri;
+        if (!operationSpec.baseUrl) {
+          throw new Error("If operationSpec.baseUrl is not specified, then the ServiceClient must have a baseUri string property that contains the base URL to use.");
+        }
+      }
+
       httpRequest.method = operationSpec.httpMethod;
       httpRequest.operationSpec = operationSpec;
 


### PR DESCRIPTION
Resolves https://github.com/Azure/autorest.typescript/issues/111.

These are the necessary changes in the runtime to move OperationSpecs out of the functions that use them.