### PR TITLE
Allow withCredentials: true

### DIFF
--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -31,11 +31,6 @@ import { RequestPrepareOptions, WebResource } from "./webResource";
  */
 export interface ServiceClientOptions {
   /**
-   * @property {RequestInit} [requestOptions] The request options. Detailed info can be found
-   * here https://github.github.io/fetch/#Request
-   */
-  requestOptions?: RequestInit;
-  /**
    * @property {Array<RequestPolicyCreator>} [requestPolicyCreators] An array of functions that will be
    * invoked to create the RequestPolicy pipeline that will be used to send a HTTP request on the
    * wire.
@@ -63,6 +58,10 @@ export interface ServiceClientOptions {
    * Whether or not to generate a client request ID header for each HTTP request.
    */
   generateClientRequestIdHeader?: boolean;
+  /**
+   * Whether to include credentials in CORS requests in the browser.
+   */
+  withCredentials?: boolean;
   /**
    * If specified, a GenerateRequestIdPolicy will be added to the HTTP pipeline that will add a
    * header to all outgoing requests with this header name and a random UUID as the request ID.
@@ -95,7 +94,7 @@ export class ServiceClient {
   private readonly _requestPolicyOptions: RequestPolicyOptions;
 
   private readonly _requestPolicyCreators: RequestPolicyCreator[];
-  private readonly _requestOptions: RequestInit;
+  private readonly _withCredentials: boolean;
 
   /**
    * The ServiceClient constructor
@@ -108,11 +107,6 @@ export class ServiceClient {
     if (!options) {
       options = {};
     }
-
-    if (!options.requestOptions) {
-      options.requestOptions = {};
-    }
-    this._requestOptions = options.requestOptions;
 
     this.userAgentInfo = { value: [] };
 
@@ -128,6 +122,7 @@ export class ServiceClient {
       // do nothing
     }
 
+    this._withCredentials = options.withCredentials || false;
     this._httpClient = options.httpClient || new DefaultHttpClient();
     this._requestPolicyOptions = new RequestPolicyOptions(options.httpPipelineLogger);
 
@@ -283,8 +278,7 @@ export class ServiceClient {
         httpRequest.onDownloadProgress = operationArguments.onDownloadProgress;
       }
 
-      if (this._requestOptions.credentials === "include")
-        httpRequest.withCredentials = true;
+      httpRequest.withCredentials = this._withCredentials;
 
       serializeRequestBody(httpRequest, operationArguments, operationSpec);
 

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -95,6 +95,7 @@ export class ServiceClient {
   private readonly _requestPolicyOptions: RequestPolicyOptions;
 
   private readonly _requestPolicyCreators: RequestPolicyCreator[];
+  private readonly _requestOptions: RequestInit;
 
   /**
    * The ServiceClient constructor
@@ -111,6 +112,7 @@ export class ServiceClient {
     if (!options.requestOptions) {
       options.requestOptions = {};
     }
+    this._requestOptions = options.requestOptions;
 
     this.userAgentInfo = { value: [] };
 
@@ -280,6 +282,9 @@ export class ServiceClient {
       if (operationArguments.onDownloadProgress) {
         httpRequest.onDownloadProgress = operationArguments.onDownloadProgress;
       }
+
+      if (this._requestOptions.credentials === "include")
+        httpRequest.withCredentials = true;
 
       serializeRequestBody(httpRequest, operationArguments, operationSpec);
 

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -60,6 +60,7 @@ export interface ServiceClientOptions {
   generateClientRequestIdHeader?: boolean;
   /**
    * Whether to include credentials in CORS requests in the browser.
+   * See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials for more information.
    */
   withCredentials?: boolean;
   /**

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -52,6 +52,7 @@ export class WebResource {
   formData?: any;
   query?: { [key: string]: any; };
   operationSpec?: OperationSpec;
+  withCredentials: boolean;
 
   abortSignal?: AbortSignalLike;
 
@@ -68,6 +69,7 @@ export class WebResource {
     query?: { [key: string]: any; },
     headers?: { [key: string]: any; } | HttpHeaders,
     rawResponse = false,
+    withCredentials = false,
     abortSignal?: AbortSignalLike,
     onUploadProgress?: (progress: TransferProgressEvent) => void,
     onDownloadProgress?: (progress: TransferProgressEvent) => void) {
@@ -79,6 +81,7 @@ export class WebResource {
     this.body = body;
     this.query = query;
     this.formData = undefined;
+    this.withCredentials = withCredentials;
     this.abortSignal = abortSignal;
     this.onUploadProgress = onUploadProgress;
     this.onDownloadProgress = onDownloadProgress;
@@ -285,6 +288,7 @@ export class WebResource {
       this.query,
       this.headers && this.headers.clone(),
       this.rawResponse,
+      this.withCredentials,
       this.abortSignal,
       this.onUploadProgress,
       this.onDownloadProgress);

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -60,6 +60,7 @@ export class XhrHttpClient implements HttpClient {
       }
     }
 
+    xhr.withCredentials = true;
     xhr.open(request.method, request.url);
     for (const header of request.headers.headersArray()) {
       xhr.setRequestHeader(header.name, header.value);
@@ -91,9 +92,9 @@ export class XhrHttpClient implements HttpClient {
     } else {
       return new Promise(function(resolve, reject) {
         xhr.addEventListener("load", () => resolve({
-          request,
-          status: xhr.status,
-          headers: parseHeaders(xhr),
+            request,
+            status: xhr.status,
+            headers: parseHeaders(xhr),
           bodyAsText: xhr.responseText
         }));
         rejectOnTerminalEvent(request, xhr, reject);
@@ -105,7 +106,7 @@ export class XhrHttpClient implements HttpClient {
 function addProgressListener(xhr: XMLHttpRequestEventTarget, listener?: (progress: TransferProgressEvent) => void) {
   if (listener) {
     xhr.addEventListener("progress", rawEvent => listener({
-      loadedBytes: rawEvent.loaded,
+        loadedBytes: rawEvent.loaded,
       totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined
     }));
   }

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -60,7 +60,7 @@ export class XhrHttpClient implements HttpClient {
       }
     }
 
-    xhr.withCredentials = true;
+    xhr.withCredentials = request.withCredentials;
     xhr.open(request.method, request.url);
     for (const header of request.headers.headersArray()) {
       xhr.setRequestHeader(header.name, header.value);

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -92,9 +92,9 @@ export class XhrHttpClient implements HttpClient {
     } else {
       return new Promise(function(resolve, reject) {
         xhr.addEventListener("load", () => resolve({
-            request,
-            status: xhr.status,
-            headers: parseHeaders(xhr),
+          request,
+          status: xhr.status,
+          headers: parseHeaders(xhr),
           bodyAsText: xhr.responseText
         }));
         rejectOnTerminalEvent(request, xhr, reject);
@@ -106,7 +106,7 @@ export class XhrHttpClient implements HttpClient {
 function addProgressListener(xhr: XMLHttpRequestEventTarget, listener?: (progress: TransferProgressEvent) => void) {
   if (listener) {
     xhr.addEventListener("progress", rawEvent => listener({
-        loadedBytes: rawEvent.loaded,
+      loadedBytes: rawEvent.loaded,
       totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined
     }));
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/shared/defaultHttpClientTests.ts
+++ b/test/shared/defaultHttpClientTests.ts
@@ -98,7 +98,7 @@ describe("defaultHttpClient", () => {
 
   it("should allow canceling requests", async function () {
     const controller = getAbortController();
-    const request = new WebResource(`${baseURL}/fileupload`, "POST", new Uint8Array(1024 * 1024 * 10), undefined, undefined, true, controller.signal);
+    const request = new WebResource(`${baseURL}/fileupload`, "POST", new Uint8Array(1024 * 1024 * 10), undefined, undefined, true, undefined, controller.signal);
     const client = new DefaultHttpClient();
     const promise = client.sendRequest(request);
     controller.abort();
@@ -134,8 +134,8 @@ describe("defaultHttpClient", () => {
     const controller = getAbortController();
     const buf = new Uint8Array(1024 * 1024 * 1);
     const requests = [
-      new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, controller.signal),
-      new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, controller.signal)
+      new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, undefined, controller.signal),
+      new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, undefined, controller.signal)
     ];
     const client = new DefaultHttpClient();
     const promises = requests.map(r => client.sendRequest(r));
@@ -160,7 +160,7 @@ describe("defaultHttpClient", () => {
     let downloadNotified = false;
 
     const buf = new Uint8Array(1024 * 1024 * 1);
-    const request = new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, undefined,
+    const request = new WebResource(`${baseURL}/fileupload`, "POST", buf, undefined, undefined, true, undefined, undefined,
       ev => {
         uploadNotified = true;
         ev.should.not.be.instanceof(ProgressEvent);

--- a/test/shared/logFilterTests.ts
+++ b/test/shared/logFilterTests.ts
@@ -26,7 +26,8 @@ describe("Log filter", () => {
   },
   "body": {
     "a": 1
-  }
+  },
+  "withCredentials": false
 }
 >> Response status code: 200
 >> Body: null


### PR DESCRIPTION
Closes #162
Continuation of #161

- `withCredentials` will be provided in the `ServiceClientOptions`-- we assume that this is held in common for all requests made with a client, just like the credentials itself. We maybe could do some tricky inference to decide "oh, we have credentials, and this request is cross origin, so let's try and do the right thing"--but this seems good enough.
- Removing the unused `requestInit` property which is a breaking change