### PR TITLE
Add responseToBody method

### DIFF
--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -30,7 +30,7 @@ export {
 export {
   stripRequest, stripResponse, delay,
   executePromisesSequentially, generateUuid, encodeUri, ServiceCallback,
-  promiseToCallback, promiseToServiceCallback, isValidUuid,
+  promiseToCallback, responseToBody, promiseToServiceCallback, isValidUuid,
   applyMixins, isNode, stringifyXML, prepareXMLRootList, isDuration
 } from "./util/utils";
 export { URLBuilder, URLQuery } from "./url";

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -14,6 +14,23 @@ import { Constants } from "./constants";
 export const isNode = typeof navigator === "undefined" && typeof process !== "undefined";
 
 /**
+ * Converts a WithHttpOperationResponse method to a method returning only the body.
+ * Supports an optional callback as the last argument.
+ * @param httpOperationResponseMethod
+ * @param args
+ */
+export function responseToBody(httpOperationResponseMethod: Function, ...args: any[]) {
+  const callback = args[args.length-1];
+  if (typeof callback === "function") {
+    httpOperationResponseMethod(...args.slice(0, args.length-1))
+      .then((res: HttpOperationResponse) => callback(null, res.parsedBody, res.request, res))
+      .catch((err: any) => callback(err));
+  } else {
+    return httpOperationResponseMethod(...args).then((res: HttpOperationResponse) => res.parsedBody);
+  }
+}
+
+/**
  * Checks if a parsed URL is HTTPS
  *
  * @param {object} urlToCheck The url to check
@@ -184,6 +201,7 @@ export interface ServiceCallback<TResult> {
  * Converts a Promise to a callback.
  * @param {Promise<any>} promise The Promise to be converted to a callback
  * @returns {Function} A function that takes the callback (cb: Function): void
+ * @deprecated generated code should instead depend on responseToBody
  */
 export function promiseToCallback(promise: Promise<any>): Function {
   if (typeof promise.then !== "function") {

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -20,9 +20,10 @@ export const isNode = typeof navigator === "undefined" && typeof process !== "un
  * @param args
  */
 export function responseToBody(httpOperationResponseMethod: Function, ...args: any[]) {
-  const callback = args[args.length-1];
+  const callback = args[args.length - 1];
   if (typeof callback === "function") {
-    httpOperationResponseMethod(...args.slice(0, args.length-1))
+    httpOperationResponseMethod(...args.slice(0, args.length - 1))
+      // tslint:disable-next-line:no-null-keyword
       .then((res: HttpOperationResponse) => callback(null, res.parsedBody, res.request, res))
       .catch((err: any) => callback(err));
   } else {

--- a/test/shared/utilsTests.ts
+++ b/test/shared/utilsTests.ts
@@ -1,0 +1,70 @@
+import * as should from "should";
+import { responseToBody, HttpOperationResponse, HttpHeaders, WebResource } from "../../lib/msRest";
+
+const response: HttpOperationResponse = { status: 200, headers: new HttpHeaders(), parsedBody: { foo: 42 }, request: new WebResource() };
+
+describe("responseToBody", function() {
+    it("should pass arguments", function() {
+        let r1 = false;
+        let r2 = 0;
+        let r3: { [key: string]: string } = {};
+        const responseMethod = (p1: boolean, p2: number, opts: {}) => {
+            r1 = p1;
+            r2 = p2;
+            r3 = opts;
+            return Promise.resolve(response);
+        };
+        responseToBody(responseMethod, true, 123, { opt: "hello" }, undefined);
+        r1.should.equal(true);
+        r2.should.equal(123);
+        r3.opt.should.equal("hello");
+    });
+
+    it("should return a promise when no callback is provided", function() {
+        const result = responseToBody(() => Promise.resolve(response));
+        result!.should.be.instanceof(Promise);
+    });
+
+    it("should call the callback in the last argument", function(done) {
+        const response: HttpOperationResponse = { status: 200, headers: new HttpHeaders(), parsedBody: { foo: 42 }, request: new WebResource() };
+        const responseMethod = () => {
+            return Promise.resolve(response);
+        };
+
+        const result = responseToBody(responseMethod, (err: any, body: any, request: WebResource, innerResponse: HttpOperationResponse) => {
+            should(err).equal(null);
+            body.foo.should.equal(42);
+            request.should.equal(response.request);
+            innerResponse.should.equal(response);
+            done();
+        });
+        should(result).equal(undefined);
+    });
+
+    it("should call the callback in the second to last argument", function(done) {
+        let response: HttpOperationResponse = { status: 200, headers: new HttpHeaders(), parsedBody: { foo: 42 }, request: new WebResource() };
+        const responseMethod = () => {
+            return Promise.resolve(response);
+        };
+
+        const result = responseToBody(responseMethod, (err: any, body: any, request: WebResource, innerResponse: HttpOperationResponse) => {
+            should(err).equal(null);
+            body.foo.should.equal(42);
+            request.should.equal(response.request);
+            innerResponse.should.equal(response);
+            done();
+        }, undefined);
+        should(result).equal(undefined);
+    });
+
+    it("should pass errors to the callback", function(done) {
+        const responseMethod = () => {
+            return Promise.reject(new Error());
+        };
+
+        responseToBody(responseMethod, (err: Error) => {
+            err.should.be.instanceof(Error);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Resolves https://github.com/Azure/autorest.typescript/issues/192.

responseToBody enables a much more compact implementation of the body overloads in generated code.

Before:
```ts
  getValid(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<Models.Basic>): any {
    if (!callback && typeof options === 'function') {
      callback = options;
      options = undefined;
    }
    let cb = callback as msRest.ServiceCallback<Models.Basic>;
    if (!callback) {
      return this.getValidWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
        return Promise.resolve(operationRes.parsedBody as Models.Basic);
      }).catch((err: Error) => {
        return Promise.reject(err);
      });
    } else {
      msRest.promiseToCallback(this.getValidWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
        if (err) {
          return cb(err);
        }
        let result = data.parsedBody as Models.Basic;
        return cb(err, result, data.request, data);
      });
    }
  }
```

After:
```ts
  getValid(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<Models.Basic>): any {
    return msRest.responseToBody(this.getValidWithHttpOperationResponse.bind(this), options, callback);
  }
```