### PR TITLE
Call progress callbacks in nodejs streams

### DIFF
--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -4,30 +4,26 @@
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { Transform, Readable } from "stream";
 import * as FormData from "form-data";
-import * as tough from "isomorphic-tough-cookie";
+import * as tough from "tough-cookie";
 import { HttpClient } from "./httpClient";
 import { HttpHeaders } from "./httpHeaders";
 import { HttpOperationResponse } from "./httpOperationResponse";
 import { RestError } from "./restError";
-import { isNode } from "./util/utils";
-import { WebResource } from "./webResource";
+import { WebResource, HttpRequestBody } from "./webResource";
 
 const axiosClient = axios.create();
-
-if (isNode) {
-  // Workaround for https://github.com/axios/axios/issues/1158
-  axiosClient.interceptors.request.use(config => ({ ...config, method: config.method && config.method.toUpperCase() }));
-}
+// Workaround for https://github.com/axios/axios/issues/1158
+axiosClient.interceptors.request.use(config => ({ ...config, method: config.method && config.method.toUpperCase() }));
 
 /**
  * A HttpClient implementation that uses axios to send HTTP requests.
  */
 export class AxiosHttpClient implements HttpClient {
-  private readonly cookieJar = isNode ? new tough.CookieJar() : undefined;
+  private readonly cookieJar = new tough.CookieJar();
 
   public async sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
     if (!httpRequest) {
-      return Promise.reject(new Error("options (WebResource) cannot be null or undefined and must be of type object."));
+      throw new Error("httpRequest (WebResource) cannot be null or undefined and must be of type object.");
     }
 
     if (httpRequest.formData) {
@@ -94,28 +90,31 @@ export class AxiosHttpClient implements HttpClient {
     });
 
     const rawHeaders: { [headerName: string]: string } = httpRequest.headers.rawHeaders();
-    const bodyType = typeof httpRequest.body;
-    // Workaround for https://github.com/axios/axios/issues/755
-    // tslint:disable-next-line:no-null-keyword
-    let axiosBody = bodyType === "undefined" ? null :
-      bodyType === "function" ? httpRequest.body() :
-      httpRequest.body;
+
+    const httpRequestBody: HttpRequestBody = httpRequest.body;
+    let axiosBody =
+      // Workaround for https://github.com/axios/axios/issues/755
+      // tslint:disable-next-line:no-null-keyword
+      typeof httpRequestBody === "undefined" ? null :
+      typeof httpRequestBody === "function" ? httpRequestBody() :
+      httpRequestBody;
 
     const onUploadProgress = httpRequest.onUploadProgress;
-    if (onUploadProgress && typeof axiosBody.pipe === "function") {
+    if (onUploadProgress && axiosBody) {
       const totalBytes = parseInt(httpRequest.headers.get("Content-Length")!) || undefined;
       let loadedBytes = 0;
       const uploadReportStream = new Transform({
         transform: (chunk: string | Buffer, _encoding, callback) => {
           loadedBytes += chunk.length;
-          onUploadProgress({
-            loadedBytes,
-            totalBytes
-          });
+          onUploadProgress({ loadedBytes, totalBytes });
           callback(undefined, chunk);
         }
       });
-      (axiosBody as Readable).pipe(uploadReportStream);
+      if (isReadableStream(axiosBody)) {
+        axiosBody.pipe(uploadReportStream);
+      } else {
+        uploadReportStream.end(axiosBody);
+      }
       axiosBody = uploadReportStream;
     }
 
@@ -151,30 +150,32 @@ export class AxiosHttpClient implements HttpClient {
     const headers = new HttpHeaders(res.headers);
 
     const onDownloadProgress = httpRequest.onDownloadProgress;
-    let readableStreamBody: Readable = res.data;
-    if (httpRequest.rawResponse && onDownloadProgress) {
-      const totalBytes = parseInt(headers.get("Content-Length")!) || undefined;
-      let loadedBytes = 0;
-      const downloadReportStream = new Transform({
-        transform: (chunk: string | Buffer, _encoding, callback) => {
-          loadedBytes += chunk.length;
-          onDownloadProgress({
-            loadedBytes,
-            totalBytes
-          });
-          callback(undefined, chunk);
-        }
-      });
-      readableStreamBody.pipe(downloadReportStream);
-      readableStreamBody = downloadReportStream;
+    let responseBody: Readable | string = res.data;
+    if (onDownloadProgress) {
+      const totalBytes = parseInt(headers.get("Content-Length")!) || (responseBody as string).length || undefined;
+      if (isReadableStream(responseBody)) {
+        let loadedBytes = 0;
+        const downloadReportStream = new Transform({
+          transform: (chunk: string | Buffer, _encoding, callback) => {
+            loadedBytes += chunk.length;
+            onDownloadProgress({ loadedBytes, totalBytes });
+            callback(undefined, chunk);
+          }
+        });
+        responseBody.pipe(downloadReportStream);
+        responseBody = downloadReportStream;
+      } else if (totalBytes) {
+        // Calling callback for non-stream response for consistency with browser
+        onDownloadProgress({ loadedBytes: totalBytes, totalBytes });
+      }
     }
 
     const operationResponse: HttpOperationResponse = {
       request: httpRequest,
       status: res.status,
       headers,
-      readableStreamBody: httpRequest.rawResponse ? readableStreamBody : undefined,
-      bodyAsText: httpRequest.rawResponse ? undefined : res.data
+      readableStreamBody: httpRequest.rawResponse ? responseBody as Readable : undefined,
+      bodyAsText: httpRequest.rawResponse ? undefined : responseBody as string
     };
 
     if (this.cookieJar) {
@@ -192,6 +193,10 @@ export class AxiosHttpClient implements HttpClient {
       }
     }
 
-    return Promise.resolve(operationResponse);
+    return operationResponse;
   }
+}
+
+function isReadableStream(body: any): body is Readable {
+  return typeof body.pipe === "function";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,7 +180,8 @@
     "@types/tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ=="
+      "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
+      "dev": true
     },
     "@types/uglify-js": {
       "version": "3.0.3",
@@ -4980,15 +4981,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-tough-cookie": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-tough-cookie/-/isomorphic-tough-cookie-0.0.1.tgz",
-      "integrity": "sha512-9vV3Nl9PpBdd/LHIjBdiMYwWoAU3j+v+WvYJNkVnMrAgFBthgkIwQvwRl+M1J8R1AE51N/Dyv3nT38zzi7FSaw==",
-      "requires": {
-        "@types/tough-cookie": "^2.3.3",
-        "tough-cookie": "^2.3.4"
-      }
     },
     "isomorphic-xml2js": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/uuid": "^3.4.3",
     "axios": "^0.18.0",
     "form-data": "^2.3.2",
-    "isomorphic-tough-cookie": "^0.0.1",
+    "tough-cookie": "^2.4.3",
     "isomorphic-xml2js": "^0.1.3",
     "tslib": "^1.9.2",
     "uuid": "^3.2.1"

--- a/webpack.testconfig.ts
+++ b/webpack.testconfig.ts
@@ -31,9 +31,9 @@ const config: webpack.Configuration = {
     extensions: [".tsx", ".ts", ".js"]
   },
   node: {
-    fs: false,
+    fs: "empty",
     net: false,
-    path: false,
+    path: "empty",
     dns: false,
     tls: false,
     tty: false,

--- a/webpack.testconfig.ts
+++ b/webpack.testconfig.ts
@@ -40,7 +40,7 @@ const config: webpack.Configuration = {
     v8: false,
     Buffer: false,
     process: false,
-    stream: false
+    stream: "empty"
   }
 };
 


### PR DESCRIPTION
Fixes #168

This strives for an as-uniform-as-possible experience between nodejs and browser. The progress callbacks will be called for both stream and buffer/string arguments--it's just (I assume) there will only be one progress event in the buffer case.