### PR TITLE
Add "sideEffects": false for webpack 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,6 @@
     "local": "node ./.scripts/local.js",
     "preview": "node ./.scripts/preview.js",
     "latest": "node ./.scripts/latest.js"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
When bundling a sample I found this flag prevented webpack from including a redundant copy of the runtime in the bundle.