### PR TITLE
Browser xml

### DIFF
--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -33,7 +33,7 @@ export {
   stripRequest, stripResponse, delay,
   executePromisesSequentially, generateUuid, encodeUri, ServiceCallback,
   promiseToCallback, responseToBody, promiseToServiceCallback, isValidUuid,
-  applyMixins, isNode, stringifyXML, prepareXMLRootList, isDuration
+  applyMixins, isNode, isDuration
 } from "./util/utils";
 export { URLBuilder, URLQuery } from "./url";
 

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -24,6 +24,7 @@ import { CompositeMapper, DictionaryMapper, Mapper, MapperType, Serializer } fro
 import { URLBuilder } from "./url";
 import { Constants } from "./util/constants";
 import * as utils from "./util/utils";
+import { stringifyXML } from "./util/xml";
 import { RequestPrepareOptions, WebResource, RequestOptionsBase } from "./webResource";
 
 /**
@@ -326,10 +327,10 @@ export function serializeRequestBody(serviceClient: ServiceClient, httpRequest: 
         const isStream = typeName === MapperType.Stream;
         if (operationSpec.isXML) {
           if (typeName === MapperType.Sequence) {
-            httpRequest.body = utils.stringifyXML(utils.prepareXMLRootList(httpRequest.body, xmlElementName || xmlName || serializedName!), { rootName: xmlName || serializedName });
+            httpRequest.body = stringifyXML(utils.prepareXMLRootList(httpRequest.body, xmlElementName || xmlName || serializedName!), { rootName: xmlName || serializedName });
           }
           else if (!isStream) {
-            httpRequest.body = utils.stringifyXML(httpRequest.body, { rootName: xmlName || serializedName });
+            httpRequest.body = stringifyXML(httpRequest.body, { rootName: xmlName || serializedName });
           }
         } else if (!isStream) {
           httpRequest.body = JSON.stringify(httpRequest.body);

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import * as xml2js from "isomorphic-xml2js";
 import * as uuidv4 from "uuid/v4";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { RestError } from "../restError";
@@ -238,18 +237,6 @@ export function promiseToServiceCallback<T>(promise: Promise<HttpOperationRespon
       process.nextTick(cb, err);
     });
   };
-}
-
-export function stringifyXML(obj: any, opts?: { rootName?: string }) {
-  const builder = new xml2js.Builder({
-    explicitArray: false,
-    explicitCharkey: false,
-    rootName: (opts || {}).rootName,
-    renderOpts: {
-      pretty: false
-    }
-  });
-  return builder.buildObject(obj);
 }
 
 export function prepareXMLRootList(obj: any, elementName: string) {

--- a/lib/util/xml.browser.ts
+++ b/lib/util/xml.browser.ts
@@ -68,16 +68,15 @@ function domToObject(node: Node): any {
   return result;
 }
 
+// tslint:disable-next-line:no-null-keyword
+const doc = document.implementation.createDocument(null, null, null);
+const serializer = new XMLSerializer();
 
 export function stringifyXML(obj: any, opts?: { rootName?: string }) {
   const rootName = (opts || {}).rootName || "root";
   const dom = buildNode(obj, rootName)[0];
-  return serializer.serializeToString(dom);
+  return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + serializer.serializeToString(dom);
 }
-
-// tslint:disable-next-line:no-null-keyword
-const doc = document.implementation.createDocument(null, null, null);
-const serializer = new XMLSerializer();
 
 function buildAttributes(attrs: { [key: string]: { toString(): string; } }): Attr[] {
   const result = [];

--- a/lib/util/xml.browser.ts
+++ b/lib/util/xml.browser.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+const parser = new DOMParser();
+export function parseXML(str: string): Promise<any> {
+  try {
+    const dom = parser.parseFromString(str, "application/xml");
+    const errorMessage = getErrorMessage(dom);
+    if (errorMessage) {
+      throw new Error(errorMessage);
+    }
+
+    const obj = domToObject(dom.childNodes[0]);
+    return Promise.resolve(obj);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}
+
+const errorNS = parser.parseFromString("INVALID", "text/xml").getElementsByTagName("parsererror")[0].namespaceURI!;
+function getErrorMessage(dom: Document): string | undefined {
+  const parserErrors = dom.getElementsByTagNameNS(errorNS, "parsererror");
+  if (parserErrors.length) {
+    return parserErrors.item(0).innerHTML;
+  } else {
+    return undefined;
+  }
+}
+
+function isElement(node: Node): node is Element {
+  return !!(node as Element).attributes;
+}
+
+function domToObject(node: Node): any {
+  // empty node
+  if (node.childNodes.length === 0 && !(isElement(node) && node.hasAttributes())) {
+    return "";
+  }
+
+  if (node.childNodes.length === 1 && node.childNodes[0].nodeType === Node.TEXT_NODE) {
+    return node.childNodes[0].nodeValue;
+  }
+
+  const result: { [key: string]: any } = {};
+  for (let i = 0; i < node.childNodes.length; i++) {
+    const child = node.childNodes[i];
+    // Ignore leading/trailing whitespace nodes
+    if (child.nodeType !== Node.TEXT_NODE) {
+      if (!result[child.nodeName]) {
+        result[child.nodeName] = domToObject(child);
+      } else if (Array.isArray(result[child.nodeName])) {
+        result[child.nodeName].push(domToObject(child));
+      } else {
+        result[child.nodeName] = [result[child.nodeName], domToObject(child)];
+      }
+    }
+  }
+
+  if (isElement(node) && node.hasAttributes()) {
+    result["$"] = {};
+
+    for (let i = 0; i < node.attributes.length; i++) {
+      const attr = node.attributes[i];
+      result["$"][attr.nodeName] = attr.nodeValue;
+    }
+  }
+
+  return result;
+}
+
+
+export function stringifyXML(obj: any, opts?: { rootName?: string }) {
+  const rootName = (opts || {}).rootName || "root";
+  const dom = buildNode(obj, rootName)[0];
+  return serializer.serializeToString(dom);
+}
+
+// tslint:disable-next-line:no-null-keyword
+const doc = document.implementation.createDocument(null, null, null);
+const serializer = new XMLSerializer();
+
+function buildAttributes(attrs: { [key: string]: { toString(): string; } }): Attr[] {
+  const result = [];
+  for (const key of Object.keys(attrs)) {
+    const attr = doc.createAttribute(key);
+    attr.value = attrs[key].toString();
+    result.push(attr);
+  }
+  return result;
+}
+
+function buildNode(obj: any, elementName: string): Node[] {
+  if (typeof obj === "string" || typeof obj === "number" || typeof obj === "boolean") {
+    const elem = doc.createElement(elementName);
+    elem.textContent = obj.toString();
+    return [elem];
+  }
+  else if (Array.isArray(obj)) {
+    const result = [];
+    for (const arrayElem of obj) {
+      for (const child of buildNode(arrayElem, elementName)) {
+        result.push(child);
+      }
+    }
+    return result;
+  } else if (typeof obj === "object") {
+    const elem = doc.createElement(elementName);
+    for (const key of Object.keys(obj)) {
+      if (key === "$") {
+        for (const attr of buildAttributes(obj[key])) {
+          elem.attributes.setNamedItem(attr);
+        }
+      } else {
+        for (const child of buildNode(obj[key], key)) {
+          elem.appendChild(child);
+        }
+      }
+    }
+    return [elem];
+  }
+  else {
+    throw new Error(`Illegal value passed to buildObject: ${obj}`);
+  }
+}

--- a/lib/util/xml.ts
+++ b/lib/util/xml.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import * as xml2js from "xml2js";
+
+export function stringifyXML(obj: any, opts?: { rootName?: string }) {
+  const builder = new xml2js.Builder({
+    explicitArray: false,
+    explicitCharkey: false,
+    rootName: (opts || {}).rootName,
+    renderOpts: {
+      pretty: false
+    }
+  });
+  return builder.buildObject(obj);
+}
+
+export function parseXML(str: string): Promise<any> {
+  const xmlParser = new xml2js.Parser({
+    explicitArray: false,
+    explicitCharkey: false,
+    explicitRoot: false
+  });
+  return new Promise((resolve, reject) => {
+    xmlParser.parseString(str, (err?: Error, res?: any) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-rest-js",
-  "version": "0.16.0",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -228,6 +228,7 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
       "integrity": "sha512-Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==",
+      "dev": true,
       "requires": {
         "@types/events": "*",
         "@types/node": "*"
@@ -4981,15 +4982,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
-    },
-    "isomorphic-xml2js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/isomorphic-xml2js/-/isomorphic-xml2js-0.1.3.tgz",
-      "integrity": "sha512-dIkT2U9ritKVWF/HfHfGwm5tTnlMnknYsv7l12oJlQQgOV2CNV65pX+FHy6HFL9YP8q0JcrlNQAFRJIN2agUmQ==",
-      "requires": {
-        "@types/xml2js": "^0.4.2",
-        "xml2js": "^0.4.19"
-      }
     },
     "istextorbinary": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "./dist/lib/msRest.js": "./es/lib/msRest.js",
     "./es/lib/policies/msRestUserAgentPolicy.js": "./es/lib/policies/msRestUserAgentPolicy.stub.js",
     "./es/lib/util/base64.js": "./es/lib/util/base64.browser.js",
+    "./es/lib/util/xml.js": "./es/lib/util/xml.browser.js",
     "./es/lib/defaultHttpClient.js": "./es/lib/defaultHttpClient.browser.js"
   },
   "license": "MIT",
@@ -42,9 +43,9 @@
     "axios": "^0.18.0",
     "form-data": "^2.3.2",
     "tough-cookie": "^2.4.3",
-    "isomorphic-xml2js": "^0.1.3",
     "tslib": "^1.9.2",
-    "uuid": "^3.2.1"
+    "uuid": "^3.2.1",
+    "xml2js": "^0.4.19"
   },
   "devDependencies": {
     "@types/glob": "^5.0.35",
@@ -53,6 +54,7 @@
     "@types/tough-cookie": "^2.3.3",
     "@types/webpack": "^4.1.3",
     "@types/webpack-dev-middleware": "^2.0.1",
+    "@types/xml2js": "^0.4.3",
     "abortcontroller-polyfill": "^1.1.9",
     "express": "^4.16.3",
     "glob": "^7.1.2",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,7 @@ const config: webpack.Configuration = {
   },
   plugins: [
     new webpack.NormalModuleReplacementPlugin(/(\.).+util\/base64/, path.resolve(__dirname, "./lib/util/base64.browser.ts")),
+    new webpack.NormalModuleReplacementPlugin(/(\.).+util\/xml/, path.resolve(__dirname, "./lib/util/xml.browser.ts")),
     new webpack.NormalModuleReplacementPlugin(/(\.).+defaultHttpClient/, path.resolve(__dirname, "./lib/defaultHttpClient.browser.ts"))
   ],
   module: {

--- a/webpack.testconfig.ts
+++ b/webpack.testconfig.ts
@@ -6,15 +6,13 @@ const config: webpack.Configuration = {
   entry: [...glob.sync(path.join(__dirname, 'test/shared/**/*.ts')), ...glob.sync(path.join(__dirname, 'test/browser/**/*.ts'))],
   mode: 'development',
   devtool: 'source-map',
-  devServer: {
-    contentBase: __dirname
-  },
   output: {
     filename: 'testBundle.js',
     path: __dirname
   },
   plugins: [
     new webpack.NormalModuleReplacementPlugin(/(\.).+util\/base64/, path.resolve(__dirname, "./lib/util/base64.browser.ts")),
+    new webpack.NormalModuleReplacementPlugin(/(\.).+util\/xml/, path.resolve(__dirname, "./lib/util/xml.browser.ts")),
     new webpack.NormalModuleReplacementPlugin(/(\.).+defaultHttpClient/, path.resolve(__dirname, "./lib/defaultHttpClient.browser.ts"))
   ],
   module: {


### PR DESCRIPTION
Drops isomorphic-xml2js and uses a simplified implementation with no runtime configuration supported. Saves 4 KB--now the overhead all users have to take on for XML support is just 2 KB.

Passes autorest.typescript tests.