### PR TITLE
Export AbortSignalLike

### DIFF
--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent } from "./webResource";
+export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent, AbortSignalLike } from "./webResource";
 export { DefaultHttpClient } from "./defaultHttpClient";
 export { HttpClient } from "./httpClient";
 export { HttpHeaders } from "./httpHeaders";


### PR DESCRIPTION
I would really like if we could run some static analysis to ensure that all the types referenced in our exported types also get exported.. I can't think of a case where I'd want to hide a type declaration for something I'm using as e.g. a property type on a class.

@XiaoningLiu