### PR TITLE
Remove totalBytes property from TransferProgressEvent

### DIFF
--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -18,13 +18,7 @@ export type TransferProgressEvent = {
   /**
    * The number of bytes loaded so far.
    */
-  loadedBytes: number,
-
-  /**
-   * The total number of bytes that will be loaded.
-   * If the total number of bytes is unknown, this property will be undefined.
-   */
-  totalBytes?: number
+  loadedBytes: number
 };
 
 /**

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -107,8 +107,7 @@ export class XhrHttpClient implements HttpClient {
 function addProgressListener(xhr: XMLHttpRequestEventTarget, listener?: (progress: TransferProgressEvent) => void) {
   if (listener) {
     xhr.addEventListener("progress", rawEvent => listener({
-      loadedBytes: rawEvent.loaded,
-      totalBytes: rawEvent.lengthComputable ? rawEvent.total : undefined
+      loadedBytes: rawEvent.loaded
     }));
   }
 }


### PR DESCRIPTION
Resolves #183. See that issue for context.

This is a pretty minor breaking change and autorest.typescript had no dependency on the property. So I'm tempted to just merge this without bumping the package version while we are still before preview of our auto-generated SDKs.