### PR TITLE
Correctly interpret paged responses as arrays

### DIFF
--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -498,8 +498,17 @@ export function flattenResponse(_response: HttpOperationResponse, responseSpec: 
       });
     }
 
-    if (typeName === "Sequence") {
-      const arrayResponse = [...(_response.parsedBody) || []] as RestResponse & any[];
+    const modelProperties = typeName === "Composite" && (bodyMapper as CompositeMapper).type.modelProperties || {};
+    const isPageableResponse = Object.values(modelProperties).some(p => p.serializedName === "");
+    if (typeName === "Sequence" || isPageableResponse) {
+      const arrayResponse = [...(_response.parsedBody || [])] as RestResponse & any[];
+
+      for (const key of Object.keys(modelProperties)) {
+        if (modelProperties[key].serializedName) {
+          arrayResponse[key] = _response.parsedBody[key];
+        }
+      }
+
       if (parsedHeaders) {
         for (const key of Object.keys(parsedHeaders)) {
           arrayResponse[key] = parsedHeaders[key];


### PR DESCRIPTION
I found that the flattened responses didn't work right for paging because we already do something tricky in the serializer to convert e.g. the `{ "value": [...], nextLink: "..." }` into an array with a nextLink property.

This change more or less anticipates what the serializer is doing and carries on to produce an array with the additional properties assigned to it.

There's also a fix that needs to be made in the generator--PR will land soon.