### PR TITLE
IE fixes

### DIFF
--- a/lib/util/xml.browser.ts
+++ b/lib/util/xml.browser.ts
@@ -5,10 +5,7 @@ const parser = new DOMParser();
 export function parseXML(str: string): Promise<any> {
   try {
     const dom = parser.parseFromString(str, "application/xml");
-    const errorMessage = getErrorMessage(dom);
-    if (errorMessage) {
-      throw new Error(errorMessage);
-    }
+    throwIfError(dom);
 
     const obj = domToObject(dom.childNodes[0]);
     return Promise.resolve(obj);
@@ -17,13 +14,19 @@ export function parseXML(str: string): Promise<any> {
   }
 }
 
-const errorNS = parser.parseFromString("INVALID", "text/xml").getElementsByTagName("parsererror")[0].namespaceURI!;
-function getErrorMessage(dom: Document): string | undefined {
-  const parserErrors = dom.getElementsByTagNameNS(errorNS, "parsererror");
-  if (parserErrors.length) {
-    return parserErrors.item(0).innerHTML;
-  } else {
-    return undefined;
+let errorNS = "";
+try {
+  errorNS = parser.parseFromString('INVALID', 'text/xml').getElementsByTagName("parsererror")[0].namespaceURI!;
+} catch (ignored) {
+  // Most browsers will return a document containing <parsererror>, but IE will throw.
+}
+
+function throwIfError(dom: Document) {
+  if (errorNS) {
+    const parserErrors = dom.getElementsByTagNameNS(errorNS, "parsererror");
+    if (parserErrors.length) {
+      throw new Error(parserErrors.item(0).innerHTML);
+    }
   }
 }
 
@@ -73,7 +76,7 @@ const doc = document.implementation.createDocument(null, null, null);
 const serializer = new XMLSerializer();
 
 export function stringifyXML(obj: any, opts?: { rootName?: string }) {
-  const rootName = (opts || {}).rootName || "root";
+  const rootName = opts && opts.rootName || "root";
   const dom = buildNode(obj, rootName)[0];
   return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + serializer.serializeToString(dom);
 }

--- a/lib/util/xml.browser.ts
+++ b/lib/util/xml.browser.ts
@@ -16,7 +16,7 @@ export function parseXML(str: string): Promise<any> {
 
 let errorNS = "";
 try {
-  errorNS = parser.parseFromString('INVALID', 'text/xml').getElementsByTagName("parsererror")[0].namespaceURI!;
+  errorNS = parser.parseFromString("INVALID", "text/xml").getElementsByTagName("parsererror")[0].namespaceURI!;
 } catch (ignored) {
   // Most browsers will return a document containing <parsererror>, but IE will throw.
 }

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -60,9 +60,9 @@ export class XhrHttpClient implements HttpClient {
       }
     }
 
+    xhr.open(request.method, request.url);
     xhr.timeout = request.timeout;
     xhr.withCredentials = request.withCredentials;
-    xhr.open(request.method, request.url);
     for (const header of request.headers.headersArray()) {
       xhr.setRequestHeader(header.name, header.value);
     }

--- a/test/shared/xmlTests.ts
+++ b/test/shared/xmlTests.ts
@@ -1,0 +1,20 @@
+import { parseXML } from "../../lib/util/xml";
+import * as assert from "assert";
+
+describe("XML serializer", function () {
+  it("should parse basic XML", async function() {
+    const res = await parseXML("<foo>42</foo>");
+    assert.equal(res, 42);
+  });
+
+  it("should handle errors gracefully", async function () {
+    try {
+      await parseXML("INVALID");
+      throw new Error("did not throw");
+    } catch (err) {
+      if (err.message === "did not throw") {
+        throw err;
+      }
+    }
+  });
+});


### PR DESCRIPTION
Resolves #206

Some things are still broken in IE, but after I apply these changes, I can at least pass 255/256 of the ms-rest-js tests. @XiaoningLiu

The remaining test failure I found in ms-rest-js was related to date precision. It seems like IE can parse dates with millisecond components, but deserializing causes those milliseconds to get dropped on the floor. Don't know why.

I've found that polyfills are necessary for:
- Promise
- String.startsWith/endsWith
- (only used in test code) TextEncoder