### PR TITLE
Fix for IE 11 undefined body

### DIFF
--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -67,7 +67,9 @@ export class XhrHttpClient implements HttpClient {
       xhr.setRequestHeader(header.name, header.value);
     }
     xhr.responseType = request.streamResponseBody ? "blob" : "text";
-    xhr.send(request.body);
+
+    // tslint:disable-next-line:no-null-keyword
+    xhr.send(request.body === undefined ? null : request.body);
 
     if (request.streamResponseBody) {
       return new Promise((resolve, reject) => {

--- a/test/shared/defaultHttpClientTests.ts
+++ b/test/shared/defaultHttpClientTests.ts
@@ -243,4 +243,11 @@ describe("defaultHttpClient", () => {
       err.code.should.equal("REQUEST_SEND_ERROR");
     }
   });
+
+  it("should interpret undefined as an empty body", async function () {
+    const request = new WebResource(`${baseURL}/expect-empty`, "PUT");
+    const client = new DefaultHttpClient();
+    const response = await client.sendRequest(request);
+    response.status.should.equal(200, response.bodyAsText!);
+  });
 });

--- a/testserver/index.ts
+++ b/testserver/index.ts
@@ -37,6 +37,27 @@ app.get("/slow", function(req, res) {
     }, 2000);
 });
 
+app.put("/expect-empty", function (req, res) {
+    let bufs: Buffer[] = [];
+    req.on('data', (data: Buffer) => {
+        bufs.push(data);
+    });
+    req.on('end', () => {
+        const buf = Buffer.concat(bufs);
+        if (buf.length === 0) {
+            res.status(200);
+            res.end();
+        } else {
+            res.status(400);
+            res.end("Expected empty body but got " + buf.toString('utf-8'));
+        }
+    });
+    req.on('error', err => {
+        res.status(500);
+        res.end(err);
+    });
+});
+
 app.listen(port, function() {
     console.log(`ms-rest-js testserver listening on port ${port}...`);
 });


### PR DESCRIPTION
Fixes an IE 11-specific issue reported by @XiaoningLiu where `xhr.send(undefined)` would result in the body content `undefined` going over the wire.