### PR TITLE
Fix `instanceof RestError` doens't work

### DIFF
--- a/lib/restError.ts
+++ b/lib/restError.ts
@@ -21,5 +21,7 @@ export class RestError extends Error {
     this.request = request;
     this.response = response;
     this.body = body;
+
+    Object.setPrototypeOf(this, RestError.prototype);
   }
 }


### PR DESCRIPTION
ms-rest-js throws an instance of `RestError` when it encounters HTTP error (4xx, 5xx) but the error turns out as an instance of `Error` while transpiling to ES5. It makes difficult to distinguish between a validation error (an instance of `Error`) and a REST error (an instance of `RestError` on TypeScript code, but this will be turned out as an instance of `Error` on the current implementation).

This pull request changes lib/restError.ts to follow [recommendation of TypeScript wiki](https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work). This change allows you to use `instanceof RestError` on a transpiled code.

see also https://github.com/Azure/autorest.typescript/issues/234 and thanks @RikkiGibson