### PR TITLE
Simplify polymorphic serialization

### DIFF
--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -654,15 +654,13 @@ function getPolymorphicMapper(serializer: Serializer, mapper: CompositeMapper, o
     const discriminatorAsObject: PolymorphicDiscriminator = mapper.type.polymorphicDiscriminator as PolymorphicDiscriminator;
 
     if (discriminatorAsObject &&
-      discriminatorAsObject[polymorphicPropertyName] !== null &&
-      discriminatorAsObject[polymorphicPropertyName] !== undefined) {
-      if (object === null || object === undefined) {
+      discriminatorAsObject[polymorphicPropertyName] != undefined) {
+      if (object == undefined) {
         throw new Error(`${objectName}" cannot be null or undefined. ` +
           `"${discriminatorAsObject[polymorphicPropertyName]}" is the ` +
           `polymorphicDiscriminator is a required property.`);
       }
-      if (object[discriminatorAsObject[polymorphicPropertyName]] === null ||
-        object[discriminatorAsObject[polymorphicPropertyName]] === undefined) {
+      if (object[discriminatorAsObject[polymorphicPropertyName]] == undefined) {
         throw new Error(`No discriminator field "${discriminatorAsObject[polymorphicPropertyName]}" was found in "${objectName}".`);
       }
       let indexDiscriminator = undefined;

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -640,93 +640,43 @@ function deserializeSequenceType(serializer: Serializer, mapper: SequenceMapper,
 }
 
 function getPolymorphicMapper(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
-
-  // check for polymorphic discriminator
-  // Until version 1.15.1, "polymorphicDiscriminator" in the mapper was a string. This method was not effective when the
-  // polymorphicDiscriminator property had a dot in it"s name. So we have comeup with a desgin where polymorphicDiscriminator
-  // will be an object that contains the clientName (normalized property name, ex: "odatatype") and
-  // the serializedName (ex: "odata.type") (We do not escape the dots with double backslash in this case as it is not required)
-  // Thus when serializing, the user will give us an object which will contain the normalizedProperty hence we will lookup
-  // the clientName of the polymorphicDiscriminator in the mapper and during deserialization from the responseBody we will
-  // lookup the serializedName of the polymorphicDiscriminator in the mapper. This will help us in selecting the correct mapper
-  // for the model that needs to be serializes or deserialized.
-  // We need this routing for backwards compatibility. This will absorb the breaking change in the mapper and allow new versions
-  // of the runtime to work seamlessly with older version (>= 0.17.0-Nightly20161008) of Autorest generated node.js clients.
   const polymorphicDiscriminator = mapper.type.polymorphicDiscriminator;
   if (polymorphicDiscriminator) {
-    if (typeof polymorphicDiscriminator.valueOf() === "string") {
-      return getPolymorphicMapperStringVersion(serializer, mapper, object, objectName);
-    } else if (polymorphicDiscriminator instanceof Object) {
-      return getPolymorphicMapperObjectVersion(serializer, mapper, object, objectName, mode);
+    // check for polymorphic discriminator
+    let polymorphicPropertyName = "";
+    if (mode === "serialize") {
+      polymorphicPropertyName = "clientName";
+    } else if (mode === "deserialize") {
+      polymorphicPropertyName = "serializedName";
     } else {
-      throw new Error(`The polymorphicDiscriminator for "${objectName}" is neither a string nor an object.`);
+      throw new Error(`The given mode "${mode}" for getting the polymorphic mapper for "${objectName}" is inavlid.`);
     }
+    const discriminatorAsObject: PolymorphicDiscriminator = mapper.type.polymorphicDiscriminator as PolymorphicDiscriminator;
+
+    if (discriminatorAsObject &&
+      discriminatorAsObject[polymorphicPropertyName] !== null &&
+      discriminatorAsObject[polymorphicPropertyName] !== undefined) {
+      if (object === null || object === undefined) {
+        throw new Error(`${objectName}" cannot be null or undefined. ` +
+          `"${discriminatorAsObject[polymorphicPropertyName]}" is the ` +
+          `polymorphicDiscriminator is a required property.`);
+      }
+      if (object[discriminatorAsObject[polymorphicPropertyName]] === null ||
+        object[discriminatorAsObject[polymorphicPropertyName]] === undefined) {
+        throw new Error(`No discriminator field "${discriminatorAsObject[polymorphicPropertyName]}" was found in "${objectName}".`);
+      }
+      let indexDiscriminator = undefined;
+      if (object[discriminatorAsObject[polymorphicPropertyName]] === mapper.type.uberParent) {
+        indexDiscriminator = object[discriminatorAsObject[polymorphicPropertyName]];
+      } else {
+        indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsObject[polymorphicPropertyName]];
+      }
+      if (serializer.modelMappers && serializer.modelMappers.discriminators[indexDiscriminator]) {
+        mapper = serializer.modelMappers.discriminators[indexDiscriminator];
+      }
+    }
+    return mapper;
   }
-  return mapper;
-}
-
-// processes new version of the polymorphicDiscriminator in the mapper.
-function getPolymorphicMapperObjectVersion(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
-
-  // check for polymorphic discriminator
-  let polymorphicPropertyName = "";
-  if (mode === "serialize") {
-    polymorphicPropertyName = "clientName";
-  } else if (mode === "deserialize") {
-    polymorphicPropertyName = "serializedName";
-  } else {
-    throw new Error(`The given mode "${mode}" for getting the polymorphic mapper for "${objectName}" is inavlid.`);
-  }
-  const discriminatorAsObject: PolymorphicDiscriminator = mapper.type.polymorphicDiscriminator as PolymorphicDiscriminator;
-
-  if (discriminatorAsObject &&
-    discriminatorAsObject[polymorphicPropertyName] !== null &&
-    discriminatorAsObject[polymorphicPropertyName] !== undefined) {
-    if (object === null || object === undefined) {
-      throw new Error(`${objectName}" cannot be null or undefined. ` +
-        `"${discriminatorAsObject[polymorphicPropertyName]}" is the ` +
-        `polymorphicDiscriminator is a required property.`);
-    }
-    if (object[discriminatorAsObject[polymorphicPropertyName]] === null ||
-      object[discriminatorAsObject[polymorphicPropertyName]] === undefined) {
-      throw new Error(`No discriminator field "${discriminatorAsObject[polymorphicPropertyName]}" was found in "${objectName}".`);
-    }
-    let indexDiscriminator = undefined;
-    if (object[discriminatorAsObject[polymorphicPropertyName]] === mapper.type.uberParent) {
-      indexDiscriminator = object[discriminatorAsObject[polymorphicPropertyName]];
-    } else {
-      indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsObject[polymorphicPropertyName]];
-    }
-    if (serializer.modelMappers && serializer.modelMappers.discriminators[indexDiscriminator]) {
-      mapper = serializer.modelMappers.discriminators[indexDiscriminator];
-    }
-  }
-  return mapper;
-}
-
-// processes old version of the polymorphicDiscriminator in the mapper.
-function getPolymorphicMapperStringVersion(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string): CompositeMapper {
-  // check for polymorphic discriminator
-  const discriminatorAsString: string = mapper.type.polymorphicDiscriminator as string;
-  if (discriminatorAsString != undefined) {
-    if (object == undefined) {
-      throw new Error(`${objectName}" cannot be null or undefined. "${discriminatorAsString}" is the ` +
-        `polymorphicDiscriminator is a required property.`);
-    }
-    if (object[discriminatorAsString] == undefined) {
-      throw new Error(`No discriminator field "${discriminatorAsString}" was found in "${objectName}".`);
-    }
-    let indexDiscriminator = undefined;
-    if (object[discriminatorAsString] === mapper.type.uberParent) {
-      indexDiscriminator = object[discriminatorAsString];
-    } else {
-      indexDiscriminator = mapper.type.uberParent + "." + object[discriminatorAsString];
-    }
-    if (serializer.modelMappers && serializer.modelMappers.discriminators[indexDiscriminator]) {
-      mapper = serializer.modelMappers.discriminators[indexDiscriminator];
-    }
-  }
-
   return mapper;
 }
 
@@ -775,7 +725,7 @@ export interface CompositeMapperType {
   additionalProperties?: Mapper;
 
   uberParent?: string;
-  polymorphicDiscriminator?: string | PolymorphicDiscriminator;
+  polymorphicDiscriminator?: PolymorphicDiscriminator;
 }
 
 export interface SequenceMapperType {

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -443,7 +443,7 @@ function resolveModelProperties(serializer: Serializer, mapper: CompositeMapper,
 function serializeCompositeType(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string) {
   // check for polymorphic discriminator
   if (mapper.type.polymorphicDiscriminator) {
-    mapper = getPolymorphicMapper(serializer, mapper, object, objectName, "serialize");
+    mapper = getPolymorphicMapper(serializer, mapper, object, objectName, "clientName");
   }
 
   if (object != undefined) {
@@ -516,7 +516,7 @@ function serializeCompositeType(serializer: Serializer, mapper: CompositeMapper,
 
 function deserializeCompositeType(serializer: Serializer, mapper: CompositeMapper, responseBody: any, objectName: string): any {
   if (mapper.type.polymorphicDiscriminator) {
-    mapper = getPolymorphicMapper(serializer, mapper, responseBody, objectName, "deserialize");
+    mapper = getPolymorphicMapper(serializer, mapper, responseBody, objectName, "serializedName");
   }
 
   const modelProps = resolveModelProperties(serializer, mapper, objectName);
@@ -639,22 +639,11 @@ function deserializeSequenceType(serializer: Serializer, mapper: SequenceMapper,
   return responseBody;
 }
 
-function getPolymorphicMapper(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string, mode: string): CompositeMapper {
+function getPolymorphicMapper(serializer: Serializer, mapper: CompositeMapper, object: any, objectName: string, polymorphicPropertyName: "clientName" | "serializedName"): CompositeMapper {
   const polymorphicDiscriminator = mapper.type.polymorphicDiscriminator;
   if (polymorphicDiscriminator) {
-    // check for polymorphic discriminator
-    let polymorphicPropertyName = "";
-    if (mode === "serialize") {
-      polymorphicPropertyName = "clientName";
-    } else if (mode === "deserialize") {
-      polymorphicPropertyName = "serializedName";
-    } else {
-      throw new Error(`The given mode "${mode}" for getting the polymorphic mapper for "${objectName}" is inavlid.`);
-    }
     const discriminatorAsObject: PolymorphicDiscriminator = mapper.type.polymorphicDiscriminator as PolymorphicDiscriminator;
-
-    if (discriminatorAsObject &&
-      discriminatorAsObject[polymorphicPropertyName] != undefined) {
+    if (discriminatorAsObject && discriminatorAsObject[polymorphicPropertyName] != undefined) {
       if (object == undefined) {
         throw new Error(`${objectName}" cannot be null or undefined. ` +
           `"${discriminatorAsObject[polymorphicPropertyName]}" is the ` +
@@ -673,7 +662,6 @@ function getPolymorphicMapper(serializer: Serializer, mapper: CompositeMapper, o
         mapper = serializer.modelMappers.discriminators[indexDiscriminator];
       }
     }
-    return mapper;
   }
   return mapper;
 }

--- a/test/shared/serializationTests.ts
+++ b/test/shared/serializationTests.ts
@@ -551,45 +551,6 @@ describe("msrest", function () {
       done();
     });
 
-    it("should correctly serialize string version of polymorphic discriminator", function (done) {
-      let client = new TestClient("http://localhost:9090");
-      let mapper = Mappers.PetGallery;
-      let petgallery = {
-        "id": 1,
-        "name": "Fav pet gallery",
-        "pets": [
-          {
-            "id": 2,
-            "name": "moti",
-            "food": "buiscuit",
-            "pet.type": "Dog",
-            "pettype": "Dog"
-          },
-          {
-            "id": 3,
-            "name": "billa",
-            "color": "red",
-            "pet.type": "Cat",
-            "pettype": "Cat" // In string version the user has to pass the actual property with dot and the normalized one.
-          }
-        ]
-      };
-      let serializedPetGallery = client.serializer.serialize(mapper, petgallery, "result");
-      serializedPetGallery.id.should.equal(1);
-      serializedPetGallery.name.should.equal("Fav pet gallery");
-      serializedPetGallery.pets.length.should.equal(2);
-      serializedPetGallery.pets[0]["pet.type"].should.equal("Dog");
-      serializedPetGallery.pets[0].id.should.equal(2);
-      serializedPetGallery.pets[0].name.should.equal("moti");
-      serializedPetGallery.pets[0].food.should.equal("buiscuit");
-      serializedPetGallery.pets[1]["pet.type"].should.equal("Cat");
-      serializedPetGallery.pets[1].id.should.equal(3);
-      serializedPetGallery.pets[1].name.should.equal("billa");
-      serializedPetGallery.pets[1].color.should.equal("red");
-      done();
-    });
-
-
     it("should allow null when required: true and nullable: true", function () {
       const mapper: msRest.Mapper = {
         required: false,
@@ -1009,42 +970,6 @@ describe("msrest", function () {
       deserializedSawshark.siblings[1].fishtype.should.equal("sawshark");
       deserializedSawshark.siblings[1].age.should.equal(105);
       deserializedSawshark.siblings[1].birthday.toISOString().should.equal("1900-01-05T01:00:00.000Z");
-      done();
-    });
-
-    it("should correctly deserialize string version of polymorphic discriminator", function (done) {
-      let client = new TestClient("http://localhost:9090");
-      let mapper = Mappers.PetGallery;
-      let petgallery = {
-        "id": 1,
-        "name": "Fav pet gallery",
-        "pets": [
-          {
-            "id": 2,
-            "name": "moti",
-            "food": "buiscuit",
-            "pet.type": "Dog",
-          },
-          {
-            "id": 3,
-            "name": "billa",
-            "color": "red",
-            "pet.type": "Cat",
-          }
-        ]
-      };
-      let deserializedPetGallery = client.serializer.deserialize(mapper, petgallery, "result");
-      deserializedPetGallery.id.should.equal(1);
-      deserializedPetGallery.name.should.equal("Fav pet gallery");
-      deserializedPetGallery.pets.length.should.equal(2);
-      deserializedPetGallery.pets[0]["pettype"].should.equal("Dog");
-      deserializedPetGallery.pets[0].id.should.equal(2);
-      deserializedPetGallery.pets[0].name.should.equal("moti");
-      deserializedPetGallery.pets[0].food.should.equal("buiscuit");
-      deserializedPetGallery.pets[1]["pettype"].should.equal("Cat");
-      deserializedPetGallery.pets[1].id.should.equal(3);
-      deserializedPetGallery.pets[1].name.should.equal("billa");
-      deserializedPetGallery.pets[1].color.should.equal("red");
       done();
     });
 


### PR DESCRIPTION
We don't have back compat concerns so removing `getPolymorphicMapperStringVersion` and simplifying the remaining code. The errors given could maybe be better, or even removed if we want to assume mappers are always well-formed. We don't have tests that exercise the errors as far as I know.

53 KB -> 52.2 KB fwiw.