### PR TITLE
Break cyclical reference between utils and webResource

### DIFF
--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -62,18 +62,10 @@ export function stripResponse(response: HttpOperationResponse): any {
  * @return {WebResource} The stripped version of Http Request.
  */
 export function stripRequest(request: WebResource): WebResource {
-  let strippedRequest = new WebResource();
-  try {
-    strippedRequest = request.clone();
-    if (strippedRequest.headers) {
-      strippedRequest.headers.remove("authorization");
-    }
-  } catch (err) {
-    const errMsg = err.message;
-    err.message = `Error - "${errMsg}" occured while creating a stripped version of the request object - "${request}".`;
-    return err;
+  const strippedRequest = request.clone();
+  if (strippedRequest.headers) {
+    strippedRequest.headers.remove("authorization");
   }
-
   return strippedRequest;
 }
 


### PR DESCRIPTION
Mentioned by @XiaoningLiu in https://github.com/Azure/azure-storage-js/pull/11#issuecomment-423432712

This changes a cyclic dependency on the WebResource constructor to just a cyclic dependency on the WebResource interface. TypeScript will stop emitting `import { WebResource } ...` and so rollup should stop complaining.

We are at 52 KB right now, BTW.