### PR TITLE
Ignore XML headers when deserializing XML elements with headers and text

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "--timeout",
+                "999999",
+                "--colors"
+            ],
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ]
+}

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -167,11 +167,6 @@ export class Serializer {
 
     if (mapperType.match(/^Composite$/ig) !== null) {
       payload = deserializeCompositeType(this, mapper as CompositeMapper, responseBody, objectName);
-    } else if (mapperType.match(/^Number$/ig) !== null) {
-      payload = parseFloat(responseBody);
-      if (isNaN(payload)) {
-        payload = responseBody;
-      }
     } else {
       if (this.isXML) {
         /**
@@ -184,7 +179,12 @@ export class Serializer {
         }
       }
 
-      if (mapperType.match(/^Boolean$/ig) !== null) {
+      if (mapperType.match(/^Number$/ig) !== null) {
+        payload = parseFloat(responseBody);
+        if (isNaN(payload)) {
+          payload = responseBody;
+        }
+      } else if (mapperType.match(/^Boolean$/ig) !== null) {
         if (responseBody === "true") {
           payload = true;
         } else if (responseBody === "false") {

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -165,35 +165,48 @@ export class Serializer {
       objectName = mapper.serializedName!;
     }
 
-    if (mapperType.match(/^Number$/ig) !== null) {
+    if (mapperType.match(/^Composite$/ig) !== null) {
+      payload = deserializeCompositeType(this, mapper as CompositeMapper, responseBody, objectName);
+    } else if (mapperType.match(/^Number$/ig) !== null) {
       payload = parseFloat(responseBody);
       if (isNaN(payload)) {
         payload = responseBody;
       }
-    } else if (mapperType.match(/^Boolean$/ig) !== null) {
-      if (responseBody === "true") {
-        payload = true;
-      } else if (responseBody === "false") {
-        payload = false;
-      } else {
-        payload = responseBody;
+    } else {
+      if (this.isXML) {
+        /**
+         * If the mapper specifies this as a non-composite type value but the responseBody contains
+         * both header ("$") and body ("_") properties, then just reduce the responseBody value to
+         * the body ("_") property.
+         */
+        if (responseBody["$"] != undefined && responseBody["_"] != undefined) {
+          responseBody = responseBody["_"];
+        }
       }
-    } else if (mapperType.match(/^(String|Enum|Object|Stream|Uuid|TimeSpan|any)$/ig) !== null) {
-      payload = responseBody;
-    } else if (mapperType.match(/^(Date|DateTime|DateTimeRfc1123)$/ig) !== null) {
-      payload = new Date(responseBody);
-    } else if (mapperType.match(/^UnixTime$/ig) !== null) {
-      payload = unixTimeToDate(responseBody);
-    } else if (mapperType.match(/^ByteArray$/ig) !== null) {
-      payload = base64.decodeString(responseBody);
-    } else if (mapperType.match(/^Base64Url$/ig) !== null) {
-      payload = base64UrlToByteArray(responseBody);
-    } else if (mapperType.match(/^Sequence$/ig) !== null) {
-      payload = deserializeSequenceType(this, mapper as SequenceMapper, responseBody, objectName);
-    } else if (mapperType.match(/^Dictionary$/ig) !== null) {
-      payload = deserializeDictionaryType(this, mapper as DictionaryMapper, responseBody, objectName);
-    } else if (mapperType.match(/^Composite$/ig) !== null) {
-      payload = deserializeCompositeType(this, mapper as CompositeMapper, responseBody, objectName);
+
+      if (mapperType.match(/^Boolean$/ig) !== null) {
+        if (responseBody === "true") {
+          payload = true;
+        } else if (responseBody === "false") {
+          payload = false;
+        } else {
+          payload = responseBody;
+        }
+      } else if (mapperType.match(/^(String|Enum|Object|Stream|Uuid|TimeSpan|any)$/ig) !== null) {
+        payload = responseBody;
+      } else if (mapperType.match(/^(Date|DateTime|DateTimeRfc1123)$/ig) !== null) {
+        payload = new Date(responseBody);
+      } else if (mapperType.match(/^UnixTime$/ig) !== null) {
+        payload = unixTimeToDate(responseBody);
+      } else if (mapperType.match(/^ByteArray$/ig) !== null) {
+        payload = base64.decodeString(responseBody);
+      } else if (mapperType.match(/^Base64Url$/ig) !== null) {
+        payload = base64UrlToByteArray(responseBody);
+      } else if (mapperType.match(/^Sequence$/ig) !== null) {
+        payload = deserializeSequenceType(this, mapper as SequenceMapper, responseBody, objectName);
+      } else if (mapperType.match(/^Dictionary$/ig) !== null) {
+        payload = deserializeDictionaryType(this, mapper as DictionaryMapper, responseBody, objectName);
+      }
     }
 
     if (mapper.isConstant) {
@@ -297,10 +310,10 @@ function serializeBasicTypes(typeName: string, objectName: string, value: any): 
     } else if (typeName.match(/^Stream$/ig) !== null) {
       const objectType = typeof value;
       if (objectType !== "string" &&
-          objectType !== "function" &&
-          !(value instanceof ArrayBuffer) &&
-          !ArrayBuffer.isView(value) &&
-          !(typeof Blob === "function" && value instanceof Blob)) {
+        objectType !== "function" &&
+        !(value instanceof ArrayBuffer) &&
+        !ArrayBuffer.isView(value) &&
+        !(typeof Blob === "function" && value instanceof Blob)) {
         throw new Error(`${objectName} must be a string, Blob, ArrayBuffer, ArrayBufferView, or a function returning NodeJS.ReadableStream.`);
       }
     }
@@ -687,19 +700,19 @@ export type MapperType = SimpleMapperType | CompositeMapperType | SequenceMapper
 
 export interface SimpleMapperType {
   name: "Base64Url"
-    | "Boolean"
-    | "ByteArray"
-    | "Date"
-    | "DateTime"
-    | "DateTimeRfc1123"
-    | "Object"
-    | "Stream"
-    | "String"
-    | "TimeSpan"
-    | "UnixTime"
-    | "Uuid"
-    | "Number"
-    | "any";
+  | "Boolean"
+  | "ByteArray"
+  | "Date"
+  | "DateTime"
+  | "DateTimeRfc1123"
+  | "Object"
+  | "Stream"
+  | "String"
+  | "TimeSpan"
+  | "UnixTime"
+  | "Uuid"
+  | "Number"
+  | "any";
 }
 
 export interface CompositeMapperType {

--- a/test/shared/policies/deserializationPolicyTests.ts
+++ b/test/shared/policies/deserializationPolicyTests.ts
@@ -159,7 +159,7 @@ describe("deserializationPolicy", function () {
       assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
     });
 
-    it(`with xml response body, application/xml content-type, and operation spec for only value`, async function () {
+    it(`with xml response body, application/xml content-type, and operation spec for only String value`, async function () {
       const response: HttpOperationResponse = {
         request: createRequest({
           httpMethod: "GET",
@@ -200,6 +200,50 @@ describe("deserializationPolicy", function () {
       assert.strictEqual(deserializedResponse.blobBody, undefined);
       assert.strictEqual(deserializedResponse.bodyAsText, `<fruit><apples tasty="yes">3</apples></fruit>`);
       assert.deepEqual(deserializedResponse.parsedBody, { "apples": "3" });
+      assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
+    });
+
+    it(`with xml response body, application/xml content-type, and operation spec for only number value`, async function () {
+      const response: HttpOperationResponse = {
+        request: createRequest({
+          httpMethod: "GET",
+          serializer: new Serializer({}, true),
+          responses: {
+            200: {
+              bodyMapper: {
+                xmlName: "fruit",
+                serializedName: "fruit",
+                type: {
+                  name: "Composite",
+                  className: "Fruit",
+                  modelProperties: {
+                    apples: {
+                      xmlName: "apples",
+                      serializedName: "apples",
+                      type: {
+                        name: "Number"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+        status: 200,
+        headers: new HttpHeaders({
+          "content-type": "application/xml"
+        }),
+        bodyAsText: `<fruit><apples tasty="yes">3</apples></fruit>`
+      };
+
+      const deserializedResponse: HttpOperationResponse = await deserializeResponse(response);
+
+      assert(deserializedResponse);
+      assert.strictEqual(deserializedResponse.readableStreamBody, undefined);
+      assert.strictEqual(deserializedResponse.blobBody, undefined);
+      assert.strictEqual(deserializedResponse.bodyAsText, `<fruit><apples tasty="yes">3</apples></fruit>`);
+      assert.deepEqual(deserializedResponse.parsedBody, { "apples": 3 });
       assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
     });
 

--- a/test/shared/policies/deserializationPolicyTests.ts
+++ b/test/shared/policies/deserializationPolicyTests.ts
@@ -203,6 +203,61 @@ describe("deserializationPolicy", function () {
       assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
     });
 
+    it(`with xml response body, application/xml content-type, and operation spec for only headers`, async function () {
+      const response: HttpOperationResponse = {
+        request: createRequest({
+          httpMethod: "GET",
+          serializer: new Serializer({}, true),
+          responses: {
+            200: {
+              bodyMapper: {
+                xmlName: "fruit",
+                serializedName: "fruit",
+                type: {
+                  name: "Composite",
+                  className: "Fruit",
+                  modelProperties: {
+                    apples: {
+                      xmlName: "apples",
+                      serializedName: "apples",
+                      type: {
+                        name: "Composite",
+                        className: "Apples",
+                        modelProperties: {
+                          tasty: {
+                            xmlName: "tasty",
+                            xmlIsAttribute: true,
+                            serializedName: "tasty",
+                            type: {
+                              name: "String"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }),
+        status: 200,
+        headers: new HttpHeaders({
+          "content-type": "application/xml"
+        }),
+        bodyAsText: `<fruit><apples tasty="yes">3</apples></fruit>`
+      };
+
+      const deserializedResponse: HttpOperationResponse = await deserializeResponse(response);
+
+      assert(deserializedResponse);
+      assert.strictEqual(deserializedResponse.readableStreamBody, undefined);
+      assert.strictEqual(deserializedResponse.blobBody, undefined);
+      assert.strictEqual(deserializedResponse.bodyAsText, `<fruit><apples tasty="yes">3</apples></fruit>`);
+      assert.deepEqual(deserializedResponse.parsedBody, { "apples": { "tasty": "yes" } });
+      assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
+    });
+
     it(`with xml response body, application/atom+xml content-type, but no operation spec`, async function () {
       const response: HttpOperationResponse = {
         request: createRequest(),


### PR DESCRIPTION
This PR is all about this XML scenario:
```xml
<element attribute="value">text</element>
```
OpenAPI doesn't handle this scenario at all, so in your schema you have to either specify the attributes or the text. If you specify the attributes, then our generator would create a CompositeMapper. If you specify the text property (see the tests for an example), then our serializer was seeing a "StringMapper" but was given a composite object. As such, the serializer would just pass the composite object through unchanged.
This PR changes that so that the body gets passed through.