### PR TITLE
Add better sourcemap support for debugging

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1 - 2018-11-13
+
+- Improve debugging by adding rollup-plugin-sourcemaps
+
 ## 1.1.0 - 2018-11-09
 
 - Renamed NPM package to @azure/ms-rest-js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "rollup-plugin-commonjs": "^9.1.8",
     "rollup-plugin-json": "^3.1.0",
     "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-visualizer": "^0.9.2",
     "semver": "^5.5.0",
     "should": "^5.2.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import commonjs from "rollup-plugin-commonjs";
 import visualizer from "rollup-plugin-visualizer";
 import json from "rollup-plugin-json";
+import sourcemaps from "rollup-plugin-sourcemaps";
 
 const banner = `/** @license ms-rest-js
  * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -32,6 +33,7 @@ const nodeConfig = {
   plugins: [
     nodeResolve({ module: true }),
     commonjs(),
+    sourcemaps(),
     json(),
     visualizer({ filename: "dist/node-stats.html", sourcemap: true })
   ]
@@ -53,6 +55,7 @@ const browserConfig = {
   plugins: [
     nodeResolve({ module: true, browser: true }),
     commonjs(),
+    sourcemaps(),
     visualizer({ filename: "dist/browser-stats.html", sourcemap: true })
   ]
 };


### PR DESCRIPTION
Resolves https://github.com/Azure/ms-rest-js/issues/247.
Ever since we started bundling this package our debugging story has been that you have to write the code in TypeScript, but debug in JavaScript.
I looked around today and found the `rollup-plugin-sourcemaps` package that successfully maps the bundle back to the original TypeScript code. It makes for a much better debugging experience.
I tested this by debugging the unit tests in ms-rest-azure-js against my local copy of ms-rest-js.