### PR TITLE
Fix tunnel types are missing

### DIFF
--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -12,8 +12,8 @@ import { RestError } from "./restError";
 import { WebResource, HttpRequestBody } from "./webResource";
 import * as tunnel from "tunnel";
 import { ProxySettings } from "./serviceClient";
-import http from "http";
-import https from "https";
+import * as http from "http";
+import * as https from "https";
 import { URLBuilder } from "./url";
 
 /**

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -8,7 +8,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.5.1",
+  msRestVersion: "1.5.2",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "tough-cookie": "^2.4.3",
     "tslib": "^1.9.2",
     "tunnel": "0.0.6",
+    "@types/tunnel": "0.0.0",
     "uuid": "^3.2.1",
     "xml2js": "^0.4.19"
   },
@@ -68,7 +69,6 @@
     "@types/semver": "^5.5.0",
     "@types/sinon": "^5.0.6",
     "@types/tough-cookie": "^2.3.3",
-    "@types/tunnel": "0.0.0",
     "@types/uuid": "^3.4.4",
     "@types/webpack": "^4.4.13",
     "@types/webpack-dev-middleware": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
- type from tunnel is exposed but the types dependency is a dev dependency only
- use valid es6 module syntax for 'http' and 'https' packages