### PR TITLE
Set tranformResponse property of axios req. config to an identity function

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.8.10 - 2019-06-05
+- `axios` changed the way it treats properties of the request config in `0.19.0`. Previously we were setting `trasnformResponse` to `undefined`. This would indicate `axios` to not transform (`JSON.parse()`) the response body. In `0.19.0`, they are setting the default response transformer if transformResponse is set to `undefined`. This breaks our pasrsing logic where we are doing `JSON.parse()` on `operationResponse.bodyAsText`. Moreover, we are exposing the `bodyAsText` property in the generated clients. 
+Not populating this property or setting the value of this property to a parsed JSON would be a breaking change for our users.
+Hence we are setting the `transformResponse` property in the request config to an indentity function that returns the response body as-is.
+
+## 1.8.9 - 2019-06-04
+- Added build job to CI pipeline
+
 ## 1.8.8 - 2019-06-03
 - Fixed vulnerabilities by bumping `axios` to `^0.19.0`.
 - New version of axios fixed some issues hence removed one of the workarounds of uppercasing method names while following redirects [axios PR](https://github.com/axios/axios/pull/1758). 

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -125,7 +125,7 @@ export class AxiosHttpClient implements HttpClient {
         url: httpRequest.url,
         headers: rawHeaders,
         data: axiosBody,
-        transformResponse: undefined,
+        transformResponse: (data) => { return data; },
         validateStatus: () => true,
         // Workaround for https://github.com/axios/axios/issues/1362
         maxContentLength: Infinity,

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.8.8",
+  msRestVersion: "1.8.10",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
 `axios` changed the way it treats properties of the request config in `0.19.0`. Previously we were setting `trasnformResponse` to `undefined`. This would indicate `axios` to not transform (`JSON.parse()`) the response body. In `0.19.0`, they are setting the default response transformer if transformResponse is set to `undefined`. This breaks our pasrsing logic where we are doing `JSON.parse()` on `operationResponse.bodyAsText`. Moreover, we are exposing the `bodyAsText` property in the generated clients. 
Not populating this property or setting the value of this property to a parsed JSON would be a breaking change for our users.
Hence we are setting the `transformResponse` property in the request config to an indentity function that returns the response body as-is.