### PR TITLE
Added domainCredentials for authentication to EventGrid domains.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.13 - 2019-06-11
+- Added DomainCredentials class for providing credentials to publish to an Azure EventGrid domain.
+
 ## 1.8.12 - 2019-06-07
 - Added back the workaround of uppercasing method names otherwise axios causes issues with signing requests for storage data plane libraries.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.8.13 - 2019-06-11
+## 1.8.13 - 2019-06-12
 - Added DomainCredentials class for providing credentials to publish to an Azure EventGrid domain.
 
 ## 1.8.12 - 2019-06-07

--- a/lib/credentials/domainCredentials.ts
+++ b/lib/credentials/domainCredentials.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { ApiKeyCredentials, ApiKeyCredentialOptions } from "./apiKeyCredentials";
+
+export class DomainCredentials extends ApiKeyCredentials {
+    /**
+     * Creates a new EventGrid DomainCredentials object.
+     *
+     * @constructor
+     * @param {string} domainKey   The EventGrid domain key
+     */
+  constructor(domainKey: string) {
+    if (!domainKey || (domainKey && typeof domainKey !== "string")) {
+      throw new Error("domainKey cannot be null or undefined and must be of type string.");
+    }
+    const options: ApiKeyCredentialOptions = {
+      inHeader: {
+        "aeg-sas-key": domainKey
+      }
+    };
+    super(options);
+  }
+}

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -47,4 +47,5 @@ export { BasicAuthenticationCredentials } from "./credentials/basicAuthenticatio
 export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKeyCredentials";
 export { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 export { TopicCredentials } from "./credentials/topicCredentials";
+export { DomainCredentials } from "./credentials/domainCredentials";
 export { Authenticator } from "./credentials/credentials";

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.8.12",
+  msRestVersion: "1.8.13",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.8.12",
+  "version": "1.8.13",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
Added a new DomainCredentials class for make it easier to supply EventGrid domain credentials. Event Grid domain is a recently introduced concept/resource and applications can publish events to an EventGrid domain for which an api key needs to be provided, and this newly introduced DomainCredentials class makes it easy to do so.