### PR TITLE
serialization updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,9 @@
 # Changelog
+## 2.0.2 - 2019-07-11
+- Added support to not send default values while sending the request.
+- Added support to populate entities with it's default value if it is present in the mapper while deserializing the response.
+- Fixed issues with serializing and deserializing additional properties.
+
 ## 2.0.2 - 2019-07-08
 - Updated `cookieJar.setCookie()` with `{ ignoreError: true }` for `NodeFetchHttpClient`. This should silently ignore things like parse errors and invalid domains. This should resolve issues where customers using the `@azure/arm-appservice` package get an error due to mismatch in the domain [Azure/azure-sdk-for-js#1008](https://github.com/Azure/azure-sdk-for-js/issues/1008). This behavior makes it consistent with the old package [azure-arm-website](https://www.npmjs.com/package/azure-arm-website) which depends on the runtime [ms-rest](https://www.npmjs.com/package/ms-rest) that depends on the [request](https://www.npmjs.com/package/request) library which uses the [tough-cookie](https://www.npmjs.com/package/tough-cookie) package in `{ looseMode: true }` by [default](https://github.com/request/request/blob/536f0e76b249e4545c3ba2ac75e643146ebf3824/lib/cookies.js#L21) with `{ ignoreError: true }` as can be seen [here](https://github.com/request/request/blob/df346d8531ac4b8c360df301f228d5767d0e374e/request.js#L969).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # Changelog
-## 2.0.2 - 2019-07-11
+## 2.0.3 - 2019-07-11
 - Added support to not send default values while sending the request.
 - Added support to populate entities with it's default value if it is present in the mapper while deserializing the response.
 - Fixed issues with serializing and deserializing additional properties.
+- During deserialization, if the service does not provide the discriminator property then we set it. While setting the discriminator property, we compare model property name and the `clientName` of the `polymorphicDiscriminator` instead of the `serializedName` of the `polymorphicDiscriminator`.
 
 ## 2.0.2 - 2019-07-08
 - Updated `cookieJar.setCookie()` with `{ ignoreError: true }` for `NodeFetchHttpClient`. This should silently ignore things like parse errors and invalid domains. This should resolve issues where customers using the `@azure/arm-appservice` package get an error due to mismatch in the domain [Azure/azure-sdk-for-js#1008](https://github.com/Azure/azure-sdk-for-js/issues/1008). This behavior makes it consistent with the old package [azure-arm-website](https://www.npmjs.com/package/azure-arm-website) which depends on the runtime [ms-rest](https://www.npmjs.com/package/ms-rest) that depends on the [request](https://www.npmjs.com/package/request) library which uses the [tough-cookie](https://www.npmjs.com/package/tough-cookie) package in `{ looseMode: true }` by [default](https://github.com/request/request/blob/536f0e76b249e4545c3ba2ac75e643146ebf3824/lib/cookies.js#L21) with `{ ignoreError: true }` as can be seen [here](https://github.com/request/request/blob/df346d8531ac4b8c360df301f228d5767d0e374e/request.js#L969).

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,8 +2,8 @@
 ## 2.0.3 - 2019-07-11
 - Added support to not send default values while sending the request.
 - Added support to populate entities with it's default value if it is present in the mapper while deserializing the response.
-- Fixed issues with serializing and deserializing additional properties.
 - During deserialization, if the service does not provide the discriminator property then we set it. While setting the discriminator property, we compare model property name and the `clientName` of the `polymorphicDiscriminator` instead of the `serializedName` of the `polymorphicDiscriminator`.
+- Added tests for serializing and deserializing additional properties.
 
 ## 2.0.2 - 2019-07-08
 - Updated `cookieJar.setCookie()` with `{ ignoreError: true }` for `NodeFetchHttpClient`. This should silently ignore things like parse errors and invalid domains. This should resolve issues where customers using the `@azure/arm-appservice` package get an error due to mismatch in the domain [Azure/azure-sdk-for-js#1008](https://github.com/Azure/azure-sdk-for-js/issues/1008). This behavior makes it consistent with the old package [azure-arm-website](https://www.npmjs.com/package/azure-arm-website) which depends on the runtime [ms-rest](https://www.npmjs.com/package/ms-rest) that depends on the [request](https://www.npmjs.com/package/request) library which uses the [tough-cookie](https://www.npmjs.com/package/tough-cookie) package in `{ looseMode: true }` by [default](https://github.com/request/request/blob/536f0e76b249e4545c3ba2ac75e643146ebf3824/lib/cookies.js#L21) with `{ ignoreError: true }` as can be seen [here](https://github.com/request/request/blob/df346d8531ac4b8c360df301f228d5767d0e374e/request.js#L969).

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -529,7 +529,7 @@ function serializeCompositeType(serializer: Serializer, mapper: CompositeMapper,
       for (const clientPropName in object) {
         const isAdditionalProperty = propNames.every(pn => pn !== clientPropName);
         if (isAdditionalProperty) {
-          payload[clientPropName] = serializer.serialize((additionalPropertiesMapper as DictionaryMapper).type.value, object[clientPropName], objectName + '["' + clientPropName + '"]');
+          payload[clientPropName] = serializer.serialize(additionalPropertiesMapper, object[clientPropName], objectName + '["' + clientPropName + '"]');
         }
       }
     }
@@ -640,7 +640,7 @@ function deserializeCompositeType(serializer: Serializer, mapper: CompositeMappe
 
     for (const responsePropName in responseBody) {
       if (isAdditionalProperty(responsePropName)) {
-        instance[responsePropName] = serializer.deserialize((additionalPropertiesMapper as DictionaryMapper).type.value, responseBody[responsePropName], objectName + '["' + responsePropName + '"]');
+        instance[responsePropName] = serializer.deserialize(additionalPropertiesMapper, responseBody[responsePropName], objectName + '["' + responsePropName + '"]');
       }
     }
   } else if (responseBody) {

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -159,7 +159,8 @@ export class Serializer {
         // so let's do the more user-friendly thing and return an empty list.
         responseBody = [];
       }
-      if (mapper.defaultValue) {
+      // specifically check for undefined as default value can be a falsey value `0, "", false, null`
+      if (mapper.defaultValue !== undefined) {
         responseBody = mapper.defaultValue;
       }
       return responseBody;
@@ -600,7 +601,16 @@ function deserializeCompositeType(serializer: Serializer, mapper: CompositeMappe
       }
       propertyInstance = res;
       const polymorphicDiscriminator = mapper.type.polymorphicDiscriminator;
-      if (polymorphicDiscriminator && propertyMapper.serializedName === polymorphicDiscriminator.serializedName && propertyInstance == undefined) {
+      // checking that the model property name (key)(ex: "fishtype") and the
+      // clientName of the polymorphicDiscriminator {metadata} (ex: "fishtype")
+      // instead of the serializedName of the polymorphicDiscriminator (ex: "fish.type")
+      // is a better approach. The generator is not consistent with escaping '\.' in the
+      // serializedName of the property (ex: "fish\.type") that is marked as polymorphic discriminator
+      // and the serializedName of the metadata polymorphicDiscriminator (ex: "fish.type"). However,
+      // the clientName transformation of the polymorphicDiscriminator (ex: "fishtype") and
+      // the transformation of model property name (ex: "fishtype") is done consistently.
+      // Hence, it is a safer bet to rely on the clientName of the polymorphicDiscriminator.
+      if (polymorphicDiscriminator && key === polymorphicDiscriminator.clientName && propertyInstance == undefined) {
         propertyInstance = mapper.serializedName;
       }
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.0.2",
+  msRestVersion: "2.0.3",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "mocha-multi-reporters": "^1.1.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
-    "opn-cli": "^5.0.0",
     "rollup": "^1.16.6",
     "rollup-plugin-alias": "^1.5.2",
     "rollup-plugin-commonjs": "^10.0.1",

--- a/test/data/TestClient/lib/models/mappers.ts
+++ b/test/data/TestClient/lib/models/mappers.ts
@@ -226,6 +226,88 @@ internalMappers.Pet = {
     }
   }
 };
+internalMappers.PetAP = {
+  required: false,
+  serializedName: "PetAP",
+  type: {
+    name: "Composite",
+    additionalProperties: {
+      type: {
+        name: "Dictionary",
+        value: {
+          required: false,
+          serializedName: "StringElementType",
+          type: {
+            name: "String"
+          }
+        }
+      }
+    },
+    className: "PetAP",
+    modelProperties: {
+      id: {
+        required: true,
+        serializedName: "id",
+        type: {
+          name: "Number"
+        }
+      },
+      name: {
+        required: false,
+        serializedName: "name",
+        type: {
+          name: "String"
+        }
+      },
+      eyeColor: {
+        required: true,
+        serializedName: "eyeColor",
+        isConstant: true,
+        defaultValue: "brown",
+        type: {
+          name: "String"
+        }
+      },
+      favoriteFood: {
+        required: false,
+        serializedName: "favoriteFood",
+        defaultValue: "bones",
+        type: {
+          name: "String"
+        }
+      },
+      status: {
+        required: false,
+        readOnly: true,
+        serializedName: "status",
+        type: {
+          name: "Boolean"
+        }
+      },
+      odatalocation: {
+        required: true,
+        serializedName: "@odata\\.location",
+        type: {
+          name: "String"
+        }
+      },
+      additionalProperties1: {
+        required: false,
+        serializedName: "additionalProperties",
+        type: {
+          name: "Dictionary",
+          value: {
+            required: false,
+            serializedName: "NumberElementType",
+            type: {
+              name: "Number"
+            }
+          }
+        }
+      }
+    }
+  }
+};
 internalMappers.PetGallery = {
   required: false,
   serializedName: "PetGallery",

--- a/test/data/TestClient/lib/models/mappers.ts
+++ b/test/data/TestClient/lib/models/mappers.ts
@@ -233,14 +233,7 @@ internalMappers.PetAP = {
     name: "Composite",
     additionalProperties: {
       type: {
-        name: "Dictionary",
-        value: {
-          required: false,
-          serializedName: "StringElementType",
-          type: {
-            name: "String"
-          }
-        }
+        name: "String"
       }
     },
     className: "PetAP",

--- a/test/serializationTests.ts
+++ b/test/serializationTests.ts
@@ -1125,7 +1125,7 @@ describe("msrest", function () {
       done();
     });
 
-    it.skip("should correctly deserialize without failing when encountering no discriminator", function (done) {
+    it("should correctly deserialize without failing when encountering no discriminator", function (done) {
       const client = new TestClient("http://localhost:9090");
       const mapper = Mappers.Fish;
       const responseBody = {
@@ -1158,11 +1158,11 @@ describe("msrest", function () {
       deserializedSawshark.siblings.length.should.equal(1);
       deserializedSawshark.siblings[0].fishtype.should.equal("mutatedshark");
       deserializedSawshark.siblings[0].species.should.equal("dangerous");
-      deserializedSawshark.siblings[0].should.not.have.property("birthday");
-      deserializedSawshark.siblings[0].should.not.have.property("age");
+      deserializedSawshark.siblings[0].birthday.should.equal("1900-01-05T01:00:00.000Z");
+      deserializedSawshark.siblings[0].age.should.equal(105);
       deserializedSawshark.siblings[0].siblings[0].fishtype.should.equal("mutatedshark");
       deserializedSawshark.siblings[0].siblings[0].species.should.equal("predator");
-      deserializedSawshark.siblings[0].siblings[0].should.not.have.property("age");
+      deserializedSawshark.siblings[0].siblings[0].age.should.equal(6);
       done();
     });
 

--- a/test/serializationTests.ts
+++ b/test/serializationTests.ts
@@ -565,6 +565,38 @@ describe("msrest", function () {
       done();
     });
 
+    it("should correctly serialize additionalProperties when the mapper knows that additional properties are allowed", function () {
+      const bodyParameter = {
+        id: 5,
+        name: "Funny",
+        odatalocation: "westus",
+        additionalProperties1: {
+          height: 5.61,
+          weight: 599,
+          footsize: 11.5
+        },
+        color: "red",
+        city: "Seattle",
+        food: "tikka masala",
+        birthdate: "2017-12-13T02:29:51.000Z"
+      };
+      const client = new TestClient("http://localhost:9090");
+      const mapper = Mappers.PetAP;
+      const result = client.serializer.serialize(mapper, bodyParameter, "bodyParameter");
+      result.id.should.equal(5);
+      result.eyeColor.should.equal("brown");
+      assert.isUndefined(result.favoriteFood);
+      result["@odata.location"].should.equal("westus");
+      result.color.should.equal("red");
+      result.city.should.equal("Seattle");
+      result.food.should.equal("tikka masala");
+      result.additionalProperties.height.should.equal(5.61);
+      result.additionalProperties.weight.should.equal(599);
+      result.additionalProperties.footsize.should.equal(11.5);
+      result.name.should.equal("Funny");
+      result.birthdate.should.equal("2017-12-13T02:29:51.000Z");
+    });
+
     it("should allow null when required: true and nullable: true", function () {
       const mapper: msRest.Mapper = {
         required: false,
@@ -1055,6 +1087,124 @@ describe("msrest", function () {
       deserializedSawshark.siblings[0].siblings[0].species.should.equal("predator");
       deserializedSawshark.siblings[0].siblings[0].should.not.have.property("birthday");
       deserializedSawshark.siblings[0].siblings[0].age.should.equal(6);
+      done();
+    });
+
+    it("should correctly deserialize additionalProperties when the mapper knows that additional properties are allowed", function (done) {
+      const responseBody = {
+        id: 5,
+        name: "Funny",
+        status: true,
+        "@odata.location": "westus",
+        additionalProperties: {
+          height: 5.61,
+          weight: 599,
+          footsize: 11.5
+        },
+        color: "red",
+        city: "Seattle",
+        food: "tikka masala",
+        birthdate: "2017-12-13T02:29:51Z"
+      };
+      const client = new TestClient("http://localhost:9090");
+      const mapper = Mappers.PetAP;
+      const result = client.serializer.deserialize(mapper, responseBody, "responseBody");
+      result.id.should.equal(5);
+      result.status.should.equal(true);
+      result.eyeColor.should.equal("brown");
+      result.favoriteFood.should.equal("bones");
+      result.odatalocation.should.equal("westus");
+      result.color.should.equal("red");
+      result.city.should.equal("Seattle");
+      result.food.should.equal("tikka masala");
+      result.birthdate.should.equal("2017-12-13T02:29:51Z");
+      result.additionalProperties1.height.should.equal(5.61);
+      result.additionalProperties1.weight.should.equal(599);
+      result.additionalProperties1.footsize.should.equal(11.5);
+      result.name.should.equal("Funny");
+      done();
+    });
+
+    it.skip("should correctly deserialize without failing when encountering no discriminator", function (done) {
+      const client = new TestClient("http://localhost:9090");
+      const mapper = Mappers.Fish;
+      const responseBody = {
+        "age": 22,
+        "birthday": new Date("2012-01-05T01:00:00Z").toISOString(),
+        "species": "king",
+        "length": 1.0,
+        "picture": Buffer.from([255, 255, 255, 255, 254]).toString(),
+        "siblings": [
+          {
+            "fish.type": "mutatedshark",
+            "age": 105,
+            "birthday": new Date("1900-01-05T01:00:00Z").toISOString(),
+            "length": 10.0,
+            "picture": Buffer.from([255, 255, 255, 255, 254]).toString(),
+            "species": "dangerous",
+            "siblings": [
+              {
+                "fish.type": "mutatedshark",
+                "age": 6,
+                "length": 20.0,
+                "species": "predator"
+              }
+            ]
+          }
+        ]
+      };
+      const deserializedSawshark = client.serializer.deserialize(mapper, responseBody, "responseBody");
+      deserializedSawshark.fishtype.should.equal("Fish");
+      deserializedSawshark.siblings.length.should.equal(1);
+      deserializedSawshark.siblings[0].fishtype.should.equal("mutatedshark");
+      deserializedSawshark.siblings[0].species.should.equal("dangerous");
+      deserializedSawshark.siblings[0].should.not.have.property("birthday");
+      deserializedSawshark.siblings[0].should.not.have.property("age");
+      deserializedSawshark.siblings[0].siblings[0].fishtype.should.equal("mutatedshark");
+      deserializedSawshark.siblings[0].siblings[0].species.should.equal("predator");
+      deserializedSawshark.siblings[0].siblings[0].should.not.have.property("age");
+      done();
+    });
+
+    it("should correctly serialize without failing when encountering no discriminator", function (done) {
+      const client = new TestClient("http://localhost:9090");
+      const mapper = Mappers.SawShark;
+      const sawshark = {
+        "age": 22,
+        "birthday": new Date("2012-01-05T01:00:00Z"),
+        "species": "king",
+        "length": 1.0,
+        "picture": Buffer.from([255, 255, 255, 255, 254]),
+        "siblings": [
+          {
+            "fishtype": "shark",
+            "age": 6,
+            "birthday": new Date("2012-01-05T01:00:00Z"),
+            "length": 20.0,
+            "species": "predator"
+          },
+          {
+            "fishtype": "sawshark",
+            "age": 105,
+            "birthday": new Date("1900-01-05T01:00:00Z"),
+            "length": 10.0,
+            "picture": Buffer.from([255, 255, 255, 255, 254]),
+            "species": "dangerous"
+          }
+        ]
+      };
+      const serializedSawshark = client.serializer.serialize(mapper, sawshark, "result");
+      serializedSawshark.age.should.equal(22);
+      serializedSawshark["fish.type"].should.equal("sawshark");
+      serializedSawshark.siblings.length.should.equal(2);
+      serializedSawshark.siblings[0]["fish.type"].should.equal("shark");
+      serializedSawshark.siblings[0].age.should.equal(6);
+      serializedSawshark.siblings[0].birthday.should.equal(new Date("2012-01-05T01:00:00Z").toISOString());
+      serializedSawshark.siblings[1]["fish.type"].should.equal("sawshark");
+      serializedSawshark.siblings[1].age.should.equal(105);
+      serializedSawshark.siblings[1].birthday.should.equal(new Date("1900-01-05T01:00:00Z").toISOString());
+      serializedSawshark.siblings[1].picture.should.equal("//////4=");
+      serializedSawshark.picture.should.equal("//////4=");
       done();
     });
 


### PR DESCRIPTION
- Added support to not send default values while sending the request.
- Added support to populate entities with it's default value if it is present in the mapper while deserializing the response.
- During deserialization, if the service does not provide the **_discriminator_** property then we set it. While setting the _**discriminator**_ property, we compare model property name and the `clientName` of the `polymorphicDiscriminator` instead of the `serializedName` of the `polymorphicDiscriminator`.
- Added tests for serializing and deserializing additional properties.