### PR TITLE
Introduce IHttpHeaders to enable compatibility with @azure/core-http

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.14 - 2019-07-17
+- Introduced `IHttpHeaders` interface to improve compatibility with `@azure/core-http` for users of `@azure/ms-rest-nodeauth`
+
 ## 1.8.13 - 2019-06-12
 - Added DomainCredentials class for providing credentials to publish to an Azure EventGrid domain.
 

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -6,7 +6,7 @@ import { Transform, Readable } from "stream";
 import FormData from "form-data";
 import * as tough from "tough-cookie";
 import { HttpClient } from "./httpClient";
-import { HttpHeaders } from "./httpHeaders";
+import { IHttpHeaders, HttpHeaders } from "./httpHeaders";
 import { HttpOperationResponse } from "./httpOperationResponse";
 import { RestError } from "./restError";
 import { WebResource, HttpRequestBody } from "./webResource";
@@ -223,7 +223,7 @@ function isReadableStream(body: any): body is Readable {
 }
 
 declare type ProxyAgent = { isHttps: boolean; agent: http.Agent | https.Agent };
-export function createProxyAgent(requestUrl: string, proxySettings: ProxySettings, headers?: HttpHeaders): ProxyAgent {
+export function createProxyAgent(requestUrl: string, proxySettings: ProxySettings, headers?: IHttpHeaders): ProxyAgent {
   const tunnelOptions: tunnel.HttpsOverHttpsOptions = {
     proxy: {
       host: URLBuilder.parse(proxySettings.host).getHost(),

--- a/lib/httpHeaders.ts
+++ b/lib/httpHeaders.ts
@@ -24,6 +24,73 @@ export interface HttpHeader {
 }
 
 /**
+ * An interface that provides a collection of HTTP header key/value pairs.
+ */
+export interface IHttpHeaders {
+  /**
+   * Set a header in this collection with the provided name and value. The name is
+   * case-insensitive.
+   * @param headerName The name of the header to set. This value is case-insensitive.
+   * @param headerValue The value of the header to set.
+   */
+  set(headerName: string, headerValue: string | number): void;
+
+  /**
+   * Get the header value for the provided header name, or undefined if no header exists in this
+   * collection with the provided name.
+   * @param headerName The name of the header.
+   */
+  get(headerName: string): string | undefined;
+
+  /**
+   * Get whether or not this header collection contains a header entry for the provided header name.
+   */
+  contains(headerName: string): boolean;
+
+  /**
+   * Remove the header with the provided headerName. Return whether or not the header existed and
+   * was removed.
+   * @param headerName The name of the header to remove.
+   */
+  remove(headerName: string): boolean;
+
+  /**
+   * Get the headers that are contained this collection as an object.
+   */
+  rawHeaders(): RawHttpHeaders;
+
+  /**
+   * Get the headers that are contained in this collection as an array.
+   */
+  headersArray(): HttpHeader[];
+
+  /**
+   * Get the header names that are contained in this collection.
+   */
+  headerNames(): string[];
+
+  /**
+   * Get the header names that are contained in this collection.
+   */
+  headerValues(): string[];
+
+  /**
+   * Get the JSON object representation of this HTTP header collection.
+   */
+  toJson(): RawHttpHeaders;
+
+  /**
+   * Get the string representation of this HTTP header collection.
+   */
+  toString(): string;
+
+  /**
+   * Create a deep clone/copy of this HttpHeaders collection.
+   */
+  clone(): IHttpHeaders;
+}
+
+/**
  * A HttpHeaders collection represented as a simple JSON object.
  */
 export type RawHttpHeaders = { [headerName: string]: string };
@@ -145,7 +212,7 @@ export class HttpHeaders {
   /**
    * Create a deep clone/copy of this HttpHeaders collection.
    */
-  public clone(): HttpHeaders {
+  public clone(): IHttpHeaders {
     return new HttpHeaders(this.rawHeaders());
   }
 }

--- a/lib/httpOperationResponse.ts
+++ b/lib/httpOperationResponse.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { WebResource } from "./webResource";
-import { HttpHeaders } from "./httpHeaders";
+import { IHttpHeaders } from "./httpHeaders";
 
 /**
  * The properties on an HTTP response which will always be present.
@@ -21,7 +21,7 @@ export interface HttpResponse {
   /**
    * The HTTP response headers.
    */
-  headers: HttpHeaders;
+  headers: IHttpHeaders;
 }
 
 declare global {

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -4,7 +4,7 @@
 export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent, AbortSignalLike } from "./webResource";
 export { DefaultHttpClient } from "./defaultHttpClient";
 export { HttpClient } from "./httpClient";
-export { HttpHeaders } from "./httpHeaders";
+export { IHttpHeaders, HttpHeaders } from "./httpHeaders";
 export { HttpOperationResponse, HttpResponse, RestResponse } from "./httpOperationResponse";
 export { HttpPipelineLogger } from "./httpPipelineLogger";
 export { HttpPipelineLogLevel } from "./httpPipelineLogLevel";

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { HttpHeaders } from "./httpHeaders";
+import { IHttpHeaders, HttpHeaders } from "./httpHeaders";
 import { OperationSpec } from "./operationSpec";
 import { Mapper, Serializer } from "./serializer";
 import { generateUuid } from "./util/utils";
@@ -44,7 +44,7 @@ export class WebResource {
   url: string;
   method: HttpMethods;
   body?: any;
-  headers: HttpHeaders;
+  headers: IHttpHeaders;
   /**
    * Whether or not the body of the HttpOperationResponse should be treated as a stream.
    */

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.8.13",
+  "version": "1.8.14",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
This change introduces an `IHttpHeaders` interface (please give suggestions on the name) that will resolve a structural compatibility issue that prevents `ms-rest-nodeauth` from being used with SDK libraries generated with `@azure/core-http`.  The core issue is that the `HttpHeader` class uses a [`private` property](https://github.com/Azure/ms-rest-js/blob/master/lib/httpHeaders.ts#L35) which breaks structural compatibility with the same `HttpHeader` class in `@azure/core-http`.  The [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/classes.html#understanding-private) explains why:

> TypeScript is a structural type system. When we compare two different types, regardless of where they came from, if the types of all members are compatible, then we say the types themselves are compatible.
>
> However, **when comparing types that have private and protected members, we treat these types differently.** For two types to be considered compatible, if one of them has a private member, then the other must have a private member that originated in the same declaration. The same applies to protected members.

To ultimately resolve this issue, we'll have to do the following:

1. Ship a patch update in the 1.x series of `ms-rest-js` with this fix so that users of existing SDK libraries will pick it up
2. Ship a patch update in the 2.x series of `ms-rest-js` to ensure that anyone who might be using that range gets the fix
3. Ship an update to `@azure/core-http` with this fix

`ms-rest-nodeauth` itself should not need to be updated so long as its transitive dependency version of `ms-rest-js` gets updated to the fixed version.

**Question for @amarzavery**

I've built these changes on top of commit 4c755ad which was the last before the 2.x version series was introduced.  Can we create a `1.x` branch in this repo from that commit so that I can retarget this PR there?  We'll need to ship the patch update from that branch.

Once we settle on the details of this PR I'll send the equivalent changes for `master` of this repo and to `@azure/core-http`.

/cc @bterlson @ramya-rao-a 