### PR TITLE
Clone the v4x branch of autorest.typescript for testing purposes

### DIFF
--- a/.devops/azure-pipelines-pr.yml
+++ b/.devops/azure-pipelines-pr.yml
@@ -16,6 +16,7 @@ jobs:
       verbose: false
       customCommand: run build
 - job: Check_Everything
+  condition: eq(variables['System.PullRequest.TargetBranch'], 'master')
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:

--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -73,7 +73,7 @@ jobs:
       targetPath: $(System.DefaultWorkingDirectory)
   - script: 'mkdir -p $(tempDirectory)'
     displayName: 'mkdir -p $(tempDirectory)'
-  - script: 'git clone https://github.com/Azure/autorest.typescript.git autorest.typescript --recursive --depth 1'
+  - script: 'git clone -b v4x https://github.com/Azure/autorest.typescript.git autorest.typescript --recursive --depth 1'
     workingDirectory: $(tempDirectory)
     displayName: "clone autorest.typescript"
   - script: 'npm install $(Build.SourcesDirectory)/$(msRestAzureJsPackageName)'


### PR DESCRIPTION
This change fixes an issue that was discovered when PR #370 was created: this repo clones and builds the `autorest.typescript` repo during PR CI runs to verify that no unexpected breaking changes are introduced.  Since `autorest.typescript` v5 (on `master`) has made some API changes regarding credential types, we now need to explicitly clone the `v4x` branch of that repo so that the right interfaces are used.