### PR TITLE
Out of memory error on making multiple requests

### DIFF
--- a/.scripts/unit.ts
+++ b/.scripts/unit.ts
@@ -75,13 +75,13 @@ function stopTestServer(testServer: ServerProcess): void {
 
 function runNodeJsUnitTests(): number {
   console.log(`Running Node.js Unit Tests...`);
-  return executeSync(`nyc mocha`, repositoryRootFolderPath).status || 1;
+  return executeSync(`nyc mocha`, repositoryRootFolderPath).status;
 }
 
 function runBrowserUnitTests(): number {
   console.log(`Running Browser Unit Tests...`);
   const portNumber: string | number = process.env.PORT || 3001;
-  return executeSync(`${mochaChromeFilePath} http://localhost:${portNumber} --timeout 60000`, repositoryRootFolderPath).status || 1;
+  return executeSync(`${mochaChromeFilePath} http://localhost:${portNumber} --timeout 60000`, repositoryRootFolderPath).status;
 }
 
 let exitCode = 0;

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.14 - 2019-12-10
+- Fixed an issue where making many requests will cause Node.js to reach the memory allocation limit ([PR #](https://github.com/Azure/ms-rest-js/pull/375)).
+
 ## 1.8.13 - 2019-06-12
 - Added DomainCredentials class for providing credentials to publish to an Azure EventGrid domain.
 

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -16,14 +16,14 @@ import * as http from "http";
 import * as https from "https";
 import { URLBuilder } from "./url";
 
-const client = axios.create();
+export const axiosInstance = axios.create();
 
 // This hack is still required with 0.19.0 version of axios since axios tries to merge the
 // Content-Type header from it's config["<method name>"] where the method name is lower-case,
 // into the request header. It could be possible that the Content-Type header is not present
 // in the original request and this would create problems while creating the signature for
 // storage data plane sdks.
-client.interceptors.request.use((config: AxiosRequestConfig) => ({
+axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => ({
   ...config,
   method: (config.method as Method) && (config.method as Method).toUpperCase() as Method
 }));
@@ -155,7 +155,7 @@ export class AxiosHttpClient implements HttpClient {
           config.httpAgent = agent.agent;
         }
       }
-      res = await client.request(config);
+      res = await axiosInstance.request(config);
     } catch (err) {
       if (err instanceof axios.Cancel) {
         throw new RestError(err.message, RestError.REQUEST_SEND_ERROR, undefined, httpRequest);

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -16,6 +16,18 @@ import * as http from "http";
 import * as https from "https";
 import { URLBuilder } from "./url";
 
+const client = axios.create();
+
+// This hack is still required with 0.19.0 version of axios since axios tries to merge the
+// Content-Type header from it's config["<method name>"] where the method name is lower-case,
+// into the request header. It could be possible that the Content-Type header is not present
+// in the original request and this would create problems while creating the signature for
+// storage data plane sdks.
+client.interceptors.request.use((config: AxiosRequestConfig) => ({
+  ...config,
+  method: (config.method as Method) && (config.method as Method).toUpperCase() as Method
+}));
+
 /**
  * A HttpClient implementation that uses axios to send HTTP requests.
  */
@@ -143,16 +155,7 @@ export class AxiosHttpClient implements HttpClient {
           config.httpAgent = agent.agent;
         }
       }
-      // This hack is still required with 0.19.0 version of axios since axios tries to merge the
-      // Content-Type header from it's config["<method name>"] where the method name is lower-case,
-      // into the request header. It could be possible that the Content-Type header is not present
-      // in the original request and this would create problems while creating the signature for
-      // storage data plane sdks.
-      axios.interceptors.request.use((config: AxiosRequestConfig) => ({
-        ...config,
-        method: (config.method as Method) && (config.method as Method).toUpperCase() as Method
-      }));
-      res = await axios.request(config);
+      res = await client.request(config);
     } catch (err) {
       if (err instanceof axios.Cancel) {
         throw new RestError(err.message, RestError.REQUEST_SEND_ERROR, undefined, httpRequest);

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.8.13",
+  msRestVersion: "1.8.14",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.8.13",
+  "version": "1.8.14",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/defaultHttpClientTests.ts
+++ b/test/defaultHttpClientTests.ts
@@ -4,7 +4,6 @@
 import { assert, AssertionError } from "chai";
 import "chai/register-should";
 import { createReadStream } from "fs";
-import axios from "axios";
 
 import { DefaultHttpClient } from "../lib/defaultHttpClient";
 import { RestError } from "../lib/restError";
@@ -12,6 +11,7 @@ import { isNode } from "../lib/util/utils";
 import { WebResource, HttpRequestBody, TransferProgressEvent } from "../lib/webResource";
 import { getHttpMock, HttpMockFacade } from "./mockHttp";
 import { TestFunction } from "mocha";
+import { axiosInstance } from '../lib/axiosHttpClient';
 
 const nodeIt = (isNode ? it : it.skip) as TestFunction;
 
@@ -33,7 +33,7 @@ describe("defaultHttpClient", function () {
 
   let httpMock: HttpMockFacade;
   beforeEach(() => {
-    httpMock = getHttpMock(axios);
+    httpMock = getHttpMock(axiosInstance);
     httpMock.setup();
   });
   afterEach(() => httpMock.teardown());

--- a/test/defaultHttpClientTests.ts
+++ b/test/defaultHttpClientTests.ts
@@ -11,7 +11,7 @@ import { isNode } from "../lib/util/utils";
 import { WebResource, HttpRequestBody, TransferProgressEvent } from "../lib/webResource";
 import { getHttpMock, HttpMockFacade } from "./mockHttp";
 import { TestFunction } from "mocha";
-import { axiosInstance } from '../lib/axiosHttpClient';
+import { axiosInstance } from "../lib/axiosHttpClient";
 
 const nodeIt = (isNode ? it : it.skip) as TestFunction;
 

--- a/test/mockHttp.ts
+++ b/test/mockHttp.ts
@@ -48,8 +48,8 @@ class NodeHttpMock implements HttpMockFacade {
     // https://github.com/ctimmerm/axios-mock-adapter/blob/8681af9c8375be4c5dc798f68a90154b5552cadd/src/index.js#L153-L166
     axiosInstance.interceptors.request.use(
       (config: AxiosRequestConfig) => ({
-          ...config,
-          method: (config.method as Method) && (config.method as Method).toLowerCase() as Method
+        ...config,
+        method: (config.method as Method) && (config.method as Method).toLowerCase() as Method
       }));
 
     // Reverse order of the handlers because Axios interceptors are stored


### PR DESCRIPTION
Fixes: #374 

Creating a separate axios instance and moving the interceptor code out of the sendRequest() method.

An interceptor was added to the static axios instance on each sendRequest() call which can lead to out of memory issue if hundreds of requests are made as the added interceptor is not ejected after the request is made.