### PR TITLE
Fix process undefined check to allow for SSR

### DIFF
--- a/lib/policies/proxyPolicy.ts
+++ b/lib/policies/proxyPolicy.ts
@@ -9,7 +9,7 @@ import { Constants } from "../util/constants";
 import { URLBuilder } from "../url";
 
 function loadEnvironmentProxyValue(): string | undefined {
-  if (!process) {
+  if (typeof process === "undefined") {
     return undefined;
   }
 


### PR DESCRIPTION
The `!process` check fails if `process` is undefined, e.g. in a browser environment. When doing server-side rendering with something like Gatsby or Next.js (in our case VuePress) the default `proxyPolicy.ts` would be used during the server render, causing an error when running the rendered site in the browser.