### PR TITLE
Expand usage of WebResource to an interface

### DIFF
--- a/.typings/rollup-plugin-alias.d.ts
+++ b/.typings/rollup-plugin-alias.d.ts
@@ -1,4 +1,0 @@
-declare module "rollup-plugin-alias" {
-    const alias(options: { [_: string]: string }) => void;
-    export default alias;
-}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 2.0.6 - 2020-04-15
+- A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`.
+
 ## 2.0.5 - 2020-01-07
 - Fix node-fetch bundling when using Webpack (PR [#376](https://github.com/Azure/ms-rest-js/pull/376)).
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.0.6 - 2020-04-15
-- A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`.
+- A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`.  This change was added to improve compatibility between `@azure/core-http` and `@azure/ms-rest-nodeauth`.
 
 ## 2.0.5 - 2020-01-07
 - Fix node-fetch bundling when using Webpack (PR [#376](https://github.com/Azure/ms-rest-js/pull/376)).

--- a/lib/browserFetchHttpClient.ts
+++ b/lib/browserFetchHttpClient.ts
@@ -3,10 +3,10 @@
 
 import { FetchHttpClient } from "./fetchHttpClient";
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 
 export class BrowserFetchHttpClient extends FetchHttpClient {
-  prepareRequest(_httpRequest: WebResource): Promise<Partial<RequestInit>> {
+  prepareRequest(_httpRequest: WebResourceLike): Promise<Partial<RequestInit>> {
     return Promise.resolve({});
   }
 

--- a/lib/credentials/apiKeyCredentials.ts
+++ b/lib/credentials/apiKeyCredentials.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { HttpHeaders } from "../httpHeaders";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { ServiceClientCredentials } from "./serviceClientCredentials";
 
 /**
@@ -51,7 +51,7 @@ export class ApiKeyCredentials implements ServiceClientCredentials {
    * @param {WebResource} webResource The WebResource to be signed.
    * @returns {Promise<WebResource>} The signed request object.
    */
-  signRequest(webResource: WebResource): Promise<WebResource> {
+  signRequest(webResource: WebResourceLike): Promise<WebResourceLike> {
     if (!webResource) {
       return Promise.reject(new Error(`webResource cannot be null or undefined and must be of type "object".`));
     }

--- a/lib/credentials/basicAuthenticationCredentials.ts
+++ b/lib/credentials/basicAuthenticationCredentials.ts
@@ -4,7 +4,7 @@
 import { HttpHeaders } from "../httpHeaders";
 import * as base64 from "../util/base64";
 import { Constants } from "../util/constants";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { ServiceClientCredentials } from "./serviceClientCredentials";
 const HeaderConstants = Constants.HeaderConstants;
 const DEFAULT_AUTHORIZATION_SCHEME = "Basic";
@@ -37,10 +37,10 @@ export class BasicAuthenticationCredentials implements ServiceClientCredentials 
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
-   * @returns {Promise<WebResource>} The signed request object.
+   * @param {WebResourceLike} webResource The WebResourceLike to be signed.
+   * @returns {Promise<WebResourceLike>} The signed request object.
    */
-  signRequest(webResource: WebResource) {
+  signRequest(webResource: WebResourceLike) {
     const credentials = `${this.userName}:${this.password}`;
     const encodedCredentials = `${this.authorizationScheme} ${base64.encodeString(credentials)}`;
     if (!webResource.headers) webResource.headers = new HttpHeaders();

--- a/lib/credentials/serviceClientCredentials.ts
+++ b/lib/credentials/serviceClientCredentials.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 
 export interface ServiceClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {WebResource} webResource The WebResource/request to be signed.
-   * @returns {Promise<WebResource>} The signed request object;
+   * @param {WebResourceLike} webResource The WebResourceLike/request to be signed.
+   * @returns {Promise<WebResourceLike>} The signed request object;
    */
-  signRequest(webResource: WebResource): Promise<WebResource>;
+  signRequest(webResource: WebResourceLike): Promise<WebResourceLike>;
 }

--- a/lib/credentials/tokenCredentials.ts
+++ b/lib/credentials/tokenCredentials.ts
@@ -3,7 +3,7 @@
 
 import { HttpHeaders } from "../httpHeaders";
 import { Constants } from "../util/constants";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { ServiceClientCredentials } from "./serviceClientCredentials";
 
 const HeaderConstants = Constants.HeaderConstants;
@@ -34,10 +34,10 @@ export class TokenCredentials implements ServiceClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
-   * @return {Promise<WebResource>} The signed request object.
+   * @param {WebResourceLike} webResource The WebResourceLike to be signed.
+   * @return {Promise<WebResourceLike>} The signed request object.
    */
-  signRequest(webResource: WebResource) {
+  signRequest(webResource: WebResourceLike) {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
     webResource.headers.set(HeaderConstants.AUTHORIZATION, `${this.authorizationScheme} ${this.token}`);
     return Promise.resolve(webResource);

--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -5,9 +5,9 @@ import AbortController from "abort-controller";
 import FormData from "form-data";
 
 import { HttpClient } from "./httpClient";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { HttpHeaders } from "./httpHeaders";
+import { HttpHeaders, HttpHeadersLike } from "./httpHeaders";
 import { RestError } from "./restError";
 import { Readable, Transform } from "stream";
 
@@ -18,7 +18,7 @@ interface FetchError extends Error {
 }
 
 export abstract class FetchHttpClient implements HttpClient {
-  async sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
+  async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
     if (!httpRequest && typeof httpRequest !== "object") {
       throw new Error("'httpRequest' (WebResource) cannot be null or undefined and must be of type object.");
     }
@@ -164,7 +164,7 @@ export abstract class FetchHttpClient implements HttpClient {
     }
   }
 
-  abstract async prepareRequest(httpRequest: WebResource): Promise<Partial<RequestInit>>;
+  abstract async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>>;
   abstract async processRequest(operationResponse: HttpOperationResponse): Promise<void>;
   abstract async fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 }
@@ -173,7 +173,7 @@ function isReadableStream(body: any): body is Readable {
   return body && typeof body.pipe === "function";
 }
 
-export function parseHeaders(headers: Headers): HttpHeaders {
+export function parseHeaders(headers: Headers): HttpHeadersLike {
   const httpHeaders = new HttpHeaders();
 
   headers.forEach((value, key) => {

--- a/lib/httpHeaders.ts
+++ b/lib/httpHeaders.ts
@@ -31,6 +31,82 @@ export type RawHttpHeaders = { [headerName: string]: string };
 /**
  * A collection of HTTP header key/value pairs.
  */
+export interface HttpHeadersLike {
+  /**
+   * Set a header in this collection with the provided name and value. The name is
+   * case-insensitive.
+   * @param headerName The name of the header to set. This value is case-insensitive.
+   * @param headerValue The value of the header to set.
+   */
+  set(headerName: string, headerValue: string | number): void;
+  /**
+   * Get the header value for the provided header name, or undefined if no header exists in this
+   * collection with the provided name.
+   * @param headerName The name of the header.
+   */
+  get(headerName: string): string | undefined;
+  /**
+   * Get whether or not this header collection contains a header entry for the provided header name.
+   */
+  contains(headerName: string): boolean;
+  /**
+   * Remove the header with the provided headerName. Return whether or not the header existed and
+   * was removed.
+   * @param headerName The name of the header to remove.
+   */
+  remove(headerName: string): boolean;
+  /**
+   * Get the headers that are contained this collection as an object.
+   */
+  rawHeaders(): RawHttpHeaders;
+  /**
+   * Get the headers that are contained in this collection as an array.
+   */
+  headersArray(): HttpHeader[];
+  /**
+   * Get the header names that are contained in this collection.
+   */
+  headerNames(): string[];
+  /**
+   * Get the header values that are contained in this collection.
+   */
+  headerValues(): string[];
+  /**
+   * Create a deep clone/copy of this HttpHeaders collection.
+   */
+  clone(): HttpHeadersLike;
+  /**
+   * Get the JSON object representation of this HTTP header collection.
+   * The result is the same as `rawHeaders()`.
+   */
+  toJson(): RawHttpHeaders;
+}
+
+export function isHttpHeadersLike(object?: any): object is HttpHeadersLike {
+  if (!object || typeof object !== "object") {
+    return false;
+  }
+
+  if (
+    typeof object.rawHeaders === "function" &&
+    typeof object.clone === "function" &&
+    typeof object.get === "function" &&
+    typeof object.set === "function" &&
+    typeof object.contains === "function" &&
+    typeof object.remove === "function" &&
+    typeof object.headersArray === "function" &&
+    typeof object.headerValues === "function" &&
+    typeof object.headerNames === "function" &&
+    typeof object.toJson === "function"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * A collection of HTTP header key/value pairs.
+ */
 export class HttpHeaders {
   private readonly _headersMap: { [headerKey: string]: HttpHeader };
 

--- a/lib/httpOperationResponse.ts
+++ b/lib/httpOperationResponse.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { WebResource } from "./webResource";
-import { HttpHeaders } from "./httpHeaders";
+import { WebResourceLike } from "./webResource";
+import { HttpHeadersLike } from "./httpHeaders";
 
 /**
  * The properties on an HTTP response which will always be present.
@@ -11,7 +11,7 @@ export interface HttpResponse {
   /**
    * The raw request
    */
-  request: WebResource;
+  request: WebResourceLike;
 
   /**
    * The HTTP response status (e.g. 200)
@@ -21,7 +21,7 @@ export interface HttpResponse {
   /**
    * The HTTP response headers.
    */
-  headers: HttpHeaders;
+  headers: HttpHeadersLike;
 }
 
 declare global {

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent, AbortSignalLike } from "./webResource";
+export { WebResource, WebResourceLike, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent, AbortSignalLike } from "./webResource";
 export { DefaultHttpClient } from "./defaultHttpClient";
 export { HttpClient } from "./httpClient";
-export { HttpHeaders } from "./httpHeaders";
+export { HttpHeaders, HttpHeadersLike } from "./httpHeaders";
 export { HttpOperationResponse, HttpResponse, RestResponse } from "./httpOperationResponse";
 export { HttpPipelineLogger } from "./httpPipelineLogger";
 export { HttpPipelineLogLevel } from "./httpPipelineLogLevel";

--- a/lib/nodeFetchHttpClient.ts
+++ b/lib/nodeFetchHttpClient.ts
@@ -8,7 +8,7 @@ import "node-fetch";
 
 import { FetchHttpClient } from "./fetchHttpClient";
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 import { createProxyAgent, ProxyAgent } from "./proxyAgent";
 
 interface GlobalWithFetch extends NodeJS.Global {
@@ -29,7 +29,7 @@ export class NodeFetchHttpClient extends FetchHttpClient {
     return fetch(input, init);
   }
 
-  async prepareRequest(httpRequest: WebResource): Promise<Partial<RequestInit>> {
+  async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>> {
     const requestInit: Partial<RequestInit & { agent?: any }> = {};
 
     if (this.cookieJar && !httpRequest.headers.get("Cookie")) {

--- a/lib/policies/deserializationPolicy.ts
+++ b/lib/policies/deserializationPolicy.ts
@@ -8,7 +8,7 @@ import { RestError } from "../restError";
 import { Mapper, MapperType } from "../serializer";
 import * as utils from "../util/utils";
 import { parseXML } from "../util/xml";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
 /**
@@ -59,14 +59,14 @@ export class DeserializationPolicy extends BaseRequestPolicy {
     this.xmlContentTypes = deserializationContentTypes && deserializationContentTypes.xml || defaultXmlContentTypes;
   }
 
-  public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(request).then((response: HttpOperationResponse) => deserializeResponseBody(this.jsonContentTypes, this.xmlContentTypes, response));
   }
 }
 
 function getOperationResponse(parsedResponse: HttpOperationResponse): undefined | OperationResponse {
   let result: OperationResponse | undefined;
-  const request: WebResource = parsedResponse.request;
+  const request: WebResourceLike = parsedResponse.request;
   const operationSpec: OperationSpec | undefined = request.operationSpec;
   if (operationSpec) {
     const operationResponseGetter: undefined | ((operationSpec: OperationSpec, response: HttpOperationResponse) => (undefined | OperationResponse)) = request.operationResponseGetter;

--- a/lib/policies/exponentialRetryPolicy.ts
+++ b/lib/policies/exponentialRetryPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 import { RestError } from "../restError";
 
@@ -72,7 +72,7 @@ export class ExponentialRetryPolicy extends BaseRequestPolicy {
     this.maxRetryInterval = isNumber(maxRetryInterval) ? maxRetryInterval : DEFAULT_CLIENT_MAX_RETRY_INTERVAL;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(request.clone())
       .then(response => retry(this, request, response))
       .catch(error => retry(this, request, error.response, undefined, error));
@@ -139,7 +139,7 @@ function updateRetryData(policy: ExponentialRetryPolicy, retryData?: RetryData, 
   return retryData;
 }
 
-function retry(policy: ExponentialRetryPolicy, request: WebResource, response?: HttpOperationResponse, retryData?: RetryData, requestError?: RetryError): Promise<HttpOperationResponse> {
+function retry(policy: ExponentialRetryPolicy, request: WebResourceLike, response?: HttpOperationResponse, retryData?: RetryData, requestError?: RetryError): Promise<HttpOperationResponse> {
   retryData = updateRetryData(policy, retryData, requestError);
   const isAborted: boolean | undefined = request.abortSignal && request.abortSignal.aborted;
   if (!isAborted && shouldRetry(policy, response && response.status, retryData)) {

--- a/lib/policies/generateClientRequestIdPolicy.ts
+++ b/lib/policies/generateClientRequestIdPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
 export function generateClientRequestIdPolicy(requestIdHeaderName = "x-ms-client-request-id"): RequestPolicyFactory {
@@ -19,7 +19,7 @@ export class GenerateClientRequestIdPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     if (!request.headers.contains(this._requestIdHeaderName)) {
       request.headers.set(this._requestIdHeaderName, utils.generateUuid());
     }

--- a/lib/policies/logPolicy.ts
+++ b/lib/policies/logPolicy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
 export function logPolicy(logger: any = console.log): RequestPolicyFactory {
@@ -21,7 +21,7 @@ export class LogPolicy extends BaseRequestPolicy {
     this.logger = logger;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(request).then(response => logResponse(this, response));
   }
 }

--- a/lib/policies/proxyPolicy.browser.ts
+++ b/lib/policies/proxyPolicy.browser.ts
@@ -4,7 +4,7 @@
 import { ProxySettings } from "../serviceClient";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 
 const proxyNotSupportedInBrowser = new Error("ProxyPolicy is not supported in browser environment");
 
@@ -26,7 +26,7 @@ export class ProxyPolicy extends BaseRequestPolicy {
     throw proxyNotSupportedInBrowser;
   }
 
-  public sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(_request: WebResourceLike): Promise<HttpOperationResponse> {
     throw proxyNotSupportedInBrowser;
   }
 }

--- a/lib/policies/proxyPolicy.ts
+++ b/lib/policies/proxyPolicy.ts
@@ -4,7 +4,7 @@
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { ProxySettings } from "../serviceClient";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { Constants } from "../util/constants";
 import { URLBuilder } from "../url";
 
@@ -58,7 +58,7 @@ export class ProxyPolicy extends BaseRequestPolicy {
     this.proxySettings = proxySettings;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     if (!request.proxySettings) {
       request.proxySettings = this.proxySettings;
     }

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { URLBuilder } from "../url";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
 export function redirectPolicy(maximumRetries = 20): RequestPolicyFactory {
@@ -19,7 +19,7 @@ export class RedirectPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(request).then(response => handleRedirect(this, response, 0));
   }
 }

--- a/lib/policies/requestPolicy.ts
+++ b/lib/policies/requestPolicy.ts
@@ -4,7 +4,7 @@
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { HttpPipelineLogger } from "../httpPipelineLogger";
 import { HttpPipelineLogLevel } from "../httpPipelineLogLevel";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 
 /**
  * Creates a new RequestPolicy per-request that uses the provided nextPolicy.
@@ -14,14 +14,14 @@ export type RequestPolicyFactory = {
 };
 
 export interface RequestPolicy {
-  sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse>;
+  sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse>;
 }
 
 export abstract class BaseRequestPolicy implements RequestPolicy {
   protected constructor(readonly _nextPolicy: RequestPolicy, readonly _options: RequestPolicyOptions) {
   }
 
-  public abstract sendRequest(webResource: WebResource): Promise<HttpOperationResponse>;
+  public abstract sendRequest(webResource: WebResourceLike): Promise<HttpOperationResponse>;
 
   /**
    * Get whether or not a log with the provided log level should be logged.

--- a/lib/policies/rpRegistrationPolicy.ts
+++ b/lib/policies/rpRegistrationPolicy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
 export function rpRegistrationPolicy(retryTimeout = 30): RequestPolicyFactory {
@@ -18,14 +18,14 @@ export class RPRegistrationPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(request.clone())
       .then(response => registerIfNeeded(this, request, response));
   }
 }
 
 
-function registerIfNeeded(policy: RPRegistrationPolicy, request: WebResource, response: HttpOperationResponse): Promise<HttpOperationResponse> {
+function registerIfNeeded(policy: RPRegistrationPolicy, request: WebResourceLike, response: HttpOperationResponse): Promise<HttpOperationResponse> {
   if (response.status === 409) {
     const rpName = checkRPNotRegisteredError(response.bodyAsText as string);
     if (rpName) {
@@ -52,12 +52,12 @@ function registerIfNeeded(policy: RPRegistrationPolicy, request: WebResource, re
 
 /**
  * Reuses the headers of the original request and url (if specified).
- * @param {WebResource} originalRequest The original request
+ * @param {WebResourceLike} originalRequest The original request
  * @param {boolean} reuseUrlToo Should the url from the original request be reused as well. Default false.
  * @returns {object} A new request object with desired headers.
  */
-function getRequestEssentials(originalRequest: WebResource, reuseUrlToo = false): WebResource {
-  const reqOptions: WebResource = originalRequest.clone();
+function getRequestEssentials(originalRequest: WebResourceLike, reuseUrlToo = false): WebResourceLike {
+  const reqOptions: WebResourceLike = originalRequest.clone();
   if (reuseUrlToo) {
     reqOptions.url = originalRequest.url;
   }
@@ -119,11 +119,11 @@ function extractSubscriptionUrl(url: string): string {
  * @param {RPRegistrationPolicy} policy The RPRegistrationPolicy this function is being called against.
  * @param {string} urlPrefix https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/
  * @param {string} provider The provider name to be registered.
- * @param {WebResource} originalRequest The original request sent by the user that returned a 409 response
+ * @param {WebResourceLike} originalRequest The original request sent by the user that returned a 409 response
  * with a message that the provider is not registered.
  * @param {registrationCallback} callback The callback that handles the RP registration
  */
-function registerRP(policy: RPRegistrationPolicy, urlPrefix: string, provider: string, originalRequest: WebResource): Promise<boolean> {
+function registerRP(policy: RPRegistrationPolicy, urlPrefix: string, provider: string, originalRequest: WebResourceLike): Promise<boolean> {
   const postUrl = `${urlPrefix}providers/${provider}/register?api-version=2016-02-01`;
   const getUrl = `${urlPrefix}providers/${provider}?api-version=2016-02-01`;
   const reqOptions = getRequestEssentials(originalRequest);
@@ -144,11 +144,11 @@ function registerRP(policy: RPRegistrationPolicy, urlPrefix: string, provider: s
  * Polling will happen till the registrationState property of the response body is "Registered".
  * @param {RPRegistrationPolicy} policy The RPRegistrationPolicy this function is being called against.
  * @param {string} url The request url for polling
- * @param {WebResource} originalRequest The original request sent by the user that returned a 409 response
+ * @param {WebResourceLike} originalRequest The original request sent by the user that returned a 409 response
  * with a message that the provider is not registered.
  * @returns {Promise<boolean>} True if RP Registration is successful.
  */
-function getRegistrationStatus(policy: RPRegistrationPolicy, url: string, originalRequest: WebResource): Promise<boolean> {
+function getRegistrationStatus(policy: RPRegistrationPolicy, url: string, originalRequest: WebResourceLike): Promise<boolean> {
   const reqOptions: any = getRequestEssentials(originalRequest);
   reqOptions.url = url;
   reqOptions.method = "GET";

--- a/lib/policies/signingPolicy.ts
+++ b/lib/policies/signingPolicy.ts
@@ -3,7 +3,7 @@
 
 import { ServiceClientCredentials } from "../credentials/serviceClientCredentials";
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicyFactory, RequestPolicy, RequestPolicyOptions } from "./requestPolicy";
 
 export function signingPolicy(authenticationProvider: ServiceClientCredentials): RequestPolicyFactory {
@@ -20,11 +20,11 @@ export class SigningPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  signRequest(request: WebResource): Promise<WebResource> {
+  signRequest(request: WebResourceLike): Promise<WebResourceLike> {
     return this.authenticationProvider.signRequest(request);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this.signRequest(request).then(nextRequest => this._nextPolicy.sendRequest(nextRequest));
   }
 }

--- a/lib/policies/systemErrorRetryPolicy.ts
+++ b/lib/policies/systemErrorRetryPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
 export interface RetryData {
@@ -54,7 +54,7 @@ export class SystemErrorRetryPolicy extends BaseRequestPolicy {
     this.maxRetryInterval = typeof maxRetryInterval === "number" ? maxRetryInterval : this.DEFAULT_CLIENT_MAX_RETRY_INTERVAL;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(request.clone()).then(response => retry(this, request, response));
   }
 }
@@ -112,7 +112,7 @@ function updateRetryData(policy: SystemErrorRetryPolicy, retryData?: RetryData, 
   return retryData;
 }
 
-function retry(policy: SystemErrorRetryPolicy, request: WebResource, operationResponse: HttpOperationResponse, retryData?: RetryData, err?: RetryError): Promise<HttpOperationResponse> {
+function retry(policy: SystemErrorRetryPolicy, request: WebResourceLike, operationResponse: HttpOperationResponse, retryData?: RetryData, err?: RetryError): Promise<HttpOperationResponse> {
   retryData = updateRetryData(policy, retryData, err);
   if (err && err.code && shouldRetry(policy, retryData) &&
     (err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT" || err.code === "ECONNREFUSED" ||

--- a/lib/policies/throttlingRetryPolicy.ts
+++ b/lib/policies/throttlingRetryPolicy.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions, RequestPolicyFactory } from "./requestPolicy";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { Constants } from "../util/constants";
 import { delay } from "../util/utils";
 
-type ResponseHandler = (httpRequest: WebResource, response: HttpOperationResponse) => Promise<HttpOperationResponse>;
+type ResponseHandler = (httpRequest: WebResourceLike, response: HttpOperationResponse) => Promise<HttpOperationResponse>;
 const StatusCodes = Constants.HttpConstants.StatusCodes;
 
 export function throttlingRetryPolicy(): RequestPolicyFactory {
@@ -32,7 +32,7 @@ export class ThrottlingRetryPolicy extends BaseRequestPolicy {
     this._handleResponse = _handleResponse || this._defaultResponseHandler;
   }
 
-  public async sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(httpRequest.clone()).then(response => {
       if (response.status !== StatusCodes.TooManyRequests) {
         return response;
@@ -42,7 +42,7 @@ export class ThrottlingRetryPolicy extends BaseRequestPolicy {
     });
   }
 
-  private async _defaultResponseHandler(httpRequest: WebResource, httpResponse: HttpOperationResponse): Promise<HttpOperationResponse> {
+  private async _defaultResponseHandler(httpRequest: WebResourceLike, httpResponse: HttpOperationResponse): Promise<HttpOperationResponse> {
     const retryAfterHeader: string | undefined = httpResponse.headers.get(Constants.HeaderConstants.RETRY_AFTER);
 
     if (retryAfterHeader) {

--- a/lib/policies/userAgentPolicy.ts
+++ b/lib/policies/userAgentPolicy.ts
@@ -4,7 +4,7 @@
 import { HttpHeaders } from "../httpHeaders";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { Constants } from "../util/constants";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { getDefaultUserAgentKey, getPlatformSpecificData } from "./msRestUserAgentPolicy";
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "./requestPolicy";
 
@@ -51,12 +51,12 @@ export class UserAgentPolicy extends BaseRequestPolicy {
     super(_nextPolicy, _options);
   }
 
-  sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     this.addUserAgentHeader(request);
     return this._nextPolicy.sendRequest(request);
   }
 
-  addUserAgentHeader(request: WebResource): void {
+  addUserAgentHeader(request: WebResourceLike): void {
     if (!request.headers) {
       request.headers = new HttpHeaders();
     }

--- a/lib/proxyAgent.ts
+++ b/lib/proxyAgent.ts
@@ -7,10 +7,10 @@ import * as tunnel from "tunnel";
 
 import { ProxySettings } from "./serviceClient";
 import { URLBuilder } from "./url";
-import { HttpHeaders } from "./httpHeaders";
+import { HttpHeadersLike } from "./httpHeaders";
 
 export type ProxyAgent = { isHttps: boolean; agent: http.Agent | https.Agent };
-export function createProxyAgent(requestUrl: string, proxySettings: ProxySettings, headers?: HttpHeaders): ProxyAgent {
+export function createProxyAgent(requestUrl: string, proxySettings: ProxySettings, headers?: HttpHeadersLike): ProxyAgent {
   const tunnelOptions: tunnel.HttpsOverHttpsOptions = {
     proxy: {
       host: URLBuilder.parse(proxySettings.host).getHost() as string,

--- a/lib/restError.ts
+++ b/lib/restError.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 
 export class RestError extends Error {
   static readonly REQUEST_SEND_ERROR: string = "REQUEST_SEND_ERROR";
@@ -11,10 +11,10 @@ export class RestError extends Error {
 
   code?: string;
   statusCode?: number;
-  request?: WebResource;
+  request?: WebResourceLike;
   response?: HttpOperationResponse;
   body?: any;
-  constructor(message: string, code?: string, statusCode?: number, request?: WebResource, response?: HttpOperationResponse, body?: any) {
+  constructor(message: string, code?: string, statusCode?: number, request?: WebResourceLike, response?: HttpOperationResponse, body?: any) {
     super(message);
     this.code = code;
     this.statusCode = statusCode;

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -23,7 +23,7 @@ import { CompositeMapper, DictionaryMapper, Mapper, MapperType, Serializer } fro
 import { URLBuilder } from "./url";
 import * as utils from "./util/utils";
 import { stringifyXML } from "./util/xml";
-import { RequestOptionsBase, RequestPrepareOptions, WebResource } from "./webResource";
+import { RequestOptionsBase, RequestPrepareOptions, WebResourceLike, isWebResourceLike, WebResource } from "./webResource";
 import { OperationResponse } from "./operationResponse";
 import { ServiceCallback } from "./util/utils";
 import { proxyPolicy, getDefaultProxySettings } from "./policies/proxyPolicy";
@@ -165,14 +165,14 @@ export class ServiceClient {
   /**
    * Send the provided httpRequest.
    */
-  sendRequest(options: RequestPrepareOptions | WebResource): Promise<HttpOperationResponse> {
+  sendRequest(options: RequestPrepareOptions | WebResourceLike): Promise<HttpOperationResponse> {
     if (options === null || options === undefined || typeof options !== "object") {
       throw new Error("options cannot be null or undefined and it must be of type object.");
     }
 
-    let httpRequest: WebResource;
+    let httpRequest: WebResourceLike;
     try {
-      if (options instanceof WebResource) {
+      if (isWebResourceLike(options)) {
         options.validateRequestProperties();
         httpRequest = options;
       } else {
@@ -338,7 +338,7 @@ export class ServiceClient {
   }
 }
 
-export function serializeRequestBody(serviceClient: ServiceClient, httpRequest: WebResource, operationArguments: OperationArguments, operationSpec: OperationSpec): void {
+export function serializeRequestBody(serviceClient: ServiceClient, httpRequest: WebResourceLike, operationArguments: OperationArguments, operationSpec: OperationSpec): void {
   if (operationSpec.requestBody && operationSpec.requestBody.mapper) {
     httpRequest.body = getOperationArgumentValueFromParameter(serviceClient, operationArguments, operationSpec.requestBody, operationSpec.serializer);
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.0.5",
+  msRestVersion: "2.0.6",
 
   /**
    * Specifies HTTP.

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -4,7 +4,7 @@
 import uuidv4 from "uuid/v4";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { RestError } from "../restError";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { Constants } from "./constants";
 
 /**
@@ -61,7 +61,7 @@ export function stripResponse(response: HttpOperationResponse): any {
  *
  * @return {WebResource} The stripped version of Http Request.
  */
-export function stripRequest(request: WebResource): WebResource {
+export function stripRequest(request: WebResourceLike): WebResourceLike {
   const strippedRequest = request.clone();
   if (strippedRequest.headers) {
     strippedRequest.headers.remove("authorization");
@@ -165,10 +165,10 @@ export interface ServiceCallback<TResult> {
    * A method that will be invoked as a callback to a service function.
    * @param {Error | RestError | null} err The error occurred if any, while executing the request; otherwise null.
    * @param {TResult} [result] The deserialized response body if an error did not occur.
-   * @param {WebResource} [request] The raw/actual request sent to the server if an error did not occur.
+   * @param {WebResourceLike} [request] The raw/actual request sent to the server if an error did not occur.
    * @param {HttpOperationResponse} [response] The raw/actual response from the server if an error did not occur.
    */
-  (err: Error | RestError | null, result?: TResult, request?: WebResource, response?: HttpOperationResponse): void;
+  (err: Error | RestError | null, result?: TResult, request?: WebResourceLike, response?: HttpOperationResponse): void;
 }
 
 /**

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { HttpHeaders } from "./httpHeaders";
+import { HttpHeaders, HttpHeadersLike, isHttpHeadersLike } from "./httpHeaders";
 import { OperationSpec } from "./operationSpec";
 import { Mapper, Serializer } from "./serializer";
 import { generateUuid } from "./util/utils";
@@ -35,6 +35,119 @@ export interface AbortSignalLike {
 }
 
 /**
+ * An abstraction over a REST call.
+ */
+export interface WebResourceLike {
+  /**
+   * The URL being accessed by the request.
+   */
+  url: string;
+  /**
+   * The HTTP method to use when making the request.
+   */
+  method: HttpMethods;
+  /**
+   * The HTTP body contents of the request.
+   */
+  body?: any;
+  /**
+   * The HTTP headers to use when making the request.
+   */
+  headers: HttpHeadersLike;
+  /**
+   * Whether or not the body of the HttpOperationResponse should be treated as a stream.
+   */
+  streamResponseBody?: boolean;
+  /**
+   * Whether or not the HttpOperationResponse should be deserialized. If this is undefined, then the
+   * HttpOperationResponse should be deserialized.
+   */
+  shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
+  /**
+   * A function that returns the proper OperationResponse for the given OperationSpec and
+   * HttpOperationResponse combination. If this is undefined, then a simple status code lookup will
+   * be used.
+   */
+  operationResponseGetter?: (
+    operationSpec: OperationSpec,
+    response: HttpOperationResponse
+  ) => undefined | OperationResponse;
+  formData?: any;
+  /**
+   * A query string represented as an object.
+   */
+  query?: { [key: string]: any };
+  /**
+   * Used to parse the response.
+   */
+  operationSpec?: OperationSpec;
+  /**
+   * If credentials (cookies) should be sent along during an XHR.
+   */
+  withCredentials: boolean;
+  /**
+   * The number of milliseconds a request can take before automatically being terminated.
+   * If the request is terminated, an `AbortError` is thrown.
+   */
+  timeout: number;
+  /**
+   * Proxy configuration.
+   */
+  proxySettings?: ProxySettings;
+  /**
+   * If the connection should be reused.
+   */
+  keepAlive?: boolean;
+
+  /**
+   * Used to abort the request later.
+   */
+  abortSignal?: AbortSignalLike;
+
+  /**
+   * Callback which fires upon upload progress.
+   */
+  onUploadProgress?: (progress: TransferProgressEvent) => void;
+
+  /** Callback which fires upon download progress. */
+  onDownloadProgress?: (progress: TransferProgressEvent) => void;
+
+  /**
+   * Validates that the required properties such as method, url, headers["Content-Type"],
+   * headers["accept-language"] are defined. It will throw an error if one of the above
+   * mentioned properties are not defined.
+   */
+  validateRequestProperties(): void;
+
+  /**
+   * Sets options on the request.
+   */
+  prepare(options: RequestPrepareOptions): WebResourceLike;
+  /**
+   * Clone this request object.
+   */
+  clone(): WebResourceLike;
+}
+
+export function isWebResourceLike(object: any): object is WebResourceLike {
+  if (typeof object !== "object") {
+    return false;
+  }
+  if (
+    typeof object.url === "string" &&
+    typeof object.method === "string" &&
+    typeof object.headers === "object" &&
+    isHttpHeadersLike(object.headers) &&
+    typeof object.validateRequestProperties === "function" &&
+    typeof object.prepare === "function" &&
+    typeof object.clone === "function"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Creates a new WebResource object.
  *
  * This class provides an abstraction over a REST call by being library / implementation agnostic and wrapping the necessary
@@ -46,7 +159,7 @@ export class WebResource {
   url: string;
   method: HttpMethods;
   body?: any;
-  headers: HttpHeaders;
+  headers: HttpHeadersLike;
   /**
    * Whether or not the body of the HttpOperationResponse should be treated as a stream.
    */
@@ -83,7 +196,7 @@ export class WebResource {
     method?: HttpMethods,
     body?: any,
     query?: { [key: string]: any; },
-    headers?: { [key: string]: any; } | HttpHeaders,
+    headers?: { [key: string]: any; } | HttpHeadersLike,
     streamResponseBody?: boolean,
     withCredentials?: boolean,
     abortSignal?: AbortSignalLike,
@@ -96,7 +209,7 @@ export class WebResource {
     this.streamResponseBody = streamResponseBody;
     this.url = url || "";
     this.method = method || "GET";
-    this.headers = (headers instanceof HttpHeaders ? headers : new HttpHeaders(headers));
+    this.headers = (isHttpHeadersLike(headers) ? headers : new HttpHeaders(headers));
     this.body = body;
     this.query = query;
     this.formData = undefined;

--- a/lib/xhrHttpClient.ts
+++ b/lib/xhrHttpClient.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from "./httpClient";
 import { HttpHeaders } from "./httpHeaders";
-import { WebResource, TransferProgressEvent } from "./webResource";
+import { WebResourceLike, TransferProgressEvent } from "./webResource";
 import { HttpOperationResponse } from "./httpOperationResponse";
 import { RestError } from "./restError";
 
@@ -11,7 +11,7 @@ import { RestError } from "./restError";
  * A HttpClient implementation that uses XMLHttpRequest to send HTTP requests.
  */
 export class XhrHttpClient implements HttpClient {
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     const xhr = new XMLHttpRequest();
 
     if (request.proxySettings) {
@@ -131,7 +131,7 @@ export function parseHeaders(xhr: XMLHttpRequest) {
   return responseHeaders;
 }
 
-function rejectOnTerminalEvent(request: WebResource, xhr: XMLHttpRequest, reject: (err: any) => void) {
+function rejectOnTerminalEvent(request: WebResourceLike, xhr: XMLHttpRequest, reject: (err: any) => void) {
   xhr.addEventListener("error", () => reject(new RestError(`Failed to send request to ${request.url}`, RestError.REQUEST_SEND_ERROR, undefined, request)));
   xhr.addEventListener("abort", () => reject(new RestError("The request was aborted", RestError.REQUEST_ABORTED_ERROR, undefined, request)));
   xhr.addEventListener("timeout", () => reject(new RestError(`timeout of ${xhr.timeout}ms exceeded`, RestError.REQUEST_SEND_ERROR, undefined, request)));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "rollup": "^1.16.6",
-    "rollup-plugin-alias": "^1.5.2",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-multi-entry": "^2.1.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,11 +1,9 @@
-/// <reference path=".typings/rollup-plugin-alias.d.ts" />
 /// <reference path=".typings/rollup-plugin-commonjs.d.ts" />
 /// <reference path=".typings/rollup-plugin-json.d.ts" />
 /// <reference path=".typings/rollup-plugin-node-resolve.d.ts" />
 /// <reference path=".typings/rollup-plugin-sourcemaps.d.ts" />
 /// <reference path=".typings/rollup-plugin-visualizer.d.ts" />
 
-import alias from "rollup-plugin-alias";
 import commonjs from "rollup-plugin-commonjs";
 import json from "rollup-plugin-json";
 import nodeResolve from "rollup-plugin-node-resolve";
@@ -69,13 +67,6 @@ const browserConfig = {
     banner
   },
   plugins: [
-    alias({
-      "./defaultHttpClient": "./defaultHttpClient.browser",
-      "./policies/msRestUserAgentPolicy": "./policies/msRestUserAgentPolicy.browser",
-      "./policies/proxyPolicy": "./policies/proxyPolicy.browser",
-      "./util/xml": "./util/xml.browser",
-      "./util/base64": "./util/base64.browser",
-    }),
     nodeResolve({
       mainFields: ["module", "main", "browser"]
     }),

--- a/test/credentialTests.ts
+++ b/test/credentialTests.ts
@@ -18,7 +18,7 @@ describe("Token credentials", () => {
       const creds = new TokenCredentials(dummyToken);
       const request = new msRest.WebResource();
 
-      creds.signRequest(request).then((signedRequest: msRest.WebResource) => {
+      creds.signRequest(request).then((signedRequest: msRest.WebResourceLike) => {
         signedRequest.headers.get("authorization")!.should.exist;
         signedRequest.headers.get("authorization")!.should.match(new RegExp("^Bearer\\s+" + dummyToken + "$"));
         done();
@@ -28,7 +28,7 @@ describe("Token credentials", () => {
     it("should set auth header with custom scheme in request", (done) => {
       const creds = new TokenCredentials(dummyToken, fakeScheme);
       const request = new msRest.WebResource();
-      creds.signRequest(request).then((signedRequest: msRest.WebResource) => {
+      creds.signRequest(request).then((signedRequest: msRest.WebResourceLike) => {
         signedRequest.headers.get("authorization")!.should.exist;
         signedRequest.headers.get("authorization")!.should.match(new RegExp("^" + fakeScheme + "\\s+" + dummyToken + "$"));
         done();
@@ -64,7 +64,7 @@ describe("Basic Authentication credentials", () => {
     it("should base64 encode the username and password and set auth header with baisc scheme in request", (done) => {
       const creds = new BasicAuthenticationCredentials(dummyUsername, dummyPassword);
       const request = new msRest.WebResource();
-      creds.signRequest(request).then((signedRequest: msRest.WebResource) => {
+      creds.signRequest(request).then((signedRequest: msRest.WebResourceLike) => {
         signedRequest.headers.get("authorization")!.should.exist;
         signedRequest.headers.get("authorization")!.should.match(new RegExp("^Basic\\s+" + encodedCredentials + "$"));
         done();
@@ -75,7 +75,7 @@ describe("Basic Authentication credentials", () => {
       const creds = new BasicAuthenticationCredentials(dummyUsername, dummyPassword, fakeScheme);
       const request = new msRest.WebResource();
 
-      creds.signRequest(request).then((signedRequest: msRest.WebResource) => {
+      creds.signRequest(request).then((signedRequest: msRest.WebResourceLike) => {
         signedRequest.headers.get("authorization")!.should.exist;
         signedRequest.headers.get("authorization")!.should.match(new RegExp("^" + fakeScheme + "\\s+" + encodedCredentials + "$"));
         done();

--- a/test/policies/deserializationPolicyTests.ts
+++ b/test/policies/deserializationPolicyTests.ts
@@ -7,11 +7,11 @@ import { HttpOperationResponse } from "../../lib/httpOperationResponse";
 import { HttpClient, OperationSpec, Serializer } from "../../lib/msRest";
 import { DeserializationPolicy, deserializationPolicy, deserializeResponseBody, defaultJsonContentTypes, defaultXmlContentTypes } from "../../lib/policies/deserializationPolicy";
 import { RequestPolicy, RequestPolicyOptions } from "../../lib/policies/requestPolicy";
-import { WebResource } from "../../lib/webResource";
+import { WebResource, WebResourceLike } from "../../lib/webResource";
 
 describe("deserializationPolicy", function () {
   const mockPolicy: RequestPolicy = {
-    sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+    sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
       return Promise.resolve({
         request: request,
         status: 200,
@@ -31,7 +31,7 @@ describe("deserializationPolicy", function () {
   });
 
   it("should parse a JSON response body", async function () {
-    const request: WebResource = createRequest();
+    const request: WebResourceLike = createRequest();
     const mockClient: HttpClient = {
       sendRequest: req => Promise.resolve({
         request: req,
@@ -47,7 +47,7 @@ describe("deserializationPolicy", function () {
   });
 
   it("should parse a JSON response body with a charset specified in Content-Type", async function () {
-    const request: WebResource = createRequest();
+    const request: WebResourceLike = createRequest();
     const mockClient: HttpClient = {
       sendRequest: req => Promise.resolve({
         request: req,
@@ -63,7 +63,7 @@ describe("deserializationPolicy", function () {
   });
 
   it("should parse a JSON response body with an uppercase Content-Type", async function () {
-    const request: WebResource = createRequest();
+    const request: WebResourceLike = createRequest();
     const mockClient: HttpClient = {
       sendRequest: req => Promise.resolve({
         request: req,
@@ -79,7 +79,7 @@ describe("deserializationPolicy", function () {
   });
 
   it("should parse a JSON response body with a missing Content-Type", async function () {
-    const request: WebResource = createRequest();
+    const request: WebResourceLike = createRequest();
     const mockClient: HttpClient = {
       sendRequest: req => Promise.resolve({
         request: req,
@@ -467,7 +467,7 @@ function deserializeResponse(response: HttpOperationResponse): Promise<HttpOpera
   return deserializeResponseBody(defaultJsonContentTypes, defaultXmlContentTypes, response);
 }
 
-function createRequest(operationSpec?: OperationSpec): WebResource {
+function createRequest(operationSpec?: OperationSpec): WebResourceLike {
   const request = new WebResource();
   request.operationSpec = operationSpec;
   return request;

--- a/test/policies/proxyPolicyTests.ts
+++ b/test/policies/proxyPolicyTests.ts
@@ -5,7 +5,7 @@ import "chai/register-should";
 import { should } from "chai";
 import { ProxySettings } from "../../lib/serviceClient";
 import { RequestPolicyOptions } from "../../lib/policies/requestPolicy";
-import { WebResource } from "../../lib/webResource";
+import { WebResource, WebResourceLike } from "../../lib/webResource";
 import { HttpHeaders } from "../../lib/httpHeaders";
 import { proxyPolicy, ProxyPolicy, getDefaultProxySettings } from "../../lib/policies/proxyPolicy";
 import { Constants } from "../../lib/msRest";
@@ -20,7 +20,7 @@ describe("ProxyPolicy", function () {
   };
 
   const emptyRequestPolicy = {
-    sendRequest: (_: WebResource) => Promise.resolve({
+    sendRequest: (_: WebResourceLike) => Promise.resolve({
       request: new WebResource(),
       status: 404,
       headers: new HttpHeaders(undefined)

--- a/test/policies/throttlingRetryPolicyTests.ts
+++ b/test/policies/throttlingRetryPolicyTests.ts
@@ -4,14 +4,14 @@
 import { assert, AssertionError } from "chai";
 import sinon from "sinon";
 import { ThrottlingRetryPolicy } from "../../lib/policies/throttlingRetryPolicy";
-import { WebResource } from "../../lib/webResource";
+import { WebResource, WebResourceLike } from "../../lib/webResource";
 import { HttpOperationResponse } from "../../lib/httpOperationResponse";
 import { HttpHeaders, RequestPolicyOptions } from "../../lib/msRest";
 
 describe("ThrottlingRetryPolicy", () => {
   class PassThroughPolicy {
     constructor(private _response: HttpOperationResponse) { }
-    public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+    public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
       const response = {
         ...this._response,
         request: request
@@ -27,7 +27,7 @@ describe("ThrottlingRetryPolicy", () => {
     headers: new HttpHeaders()
   };
 
-  function createDefaultThrottlingRetryPolicy(response?: HttpOperationResponse, actionHandler?: (httpRequest: WebResource, response: HttpOperationResponse) => Promise<HttpOperationResponse>) {
+  function createDefaultThrottlingRetryPolicy(response?: HttpOperationResponse, actionHandler?: (httpRequest: WebResourceLike, response: HttpOperationResponse) => Promise<HttpOperationResponse>) {
     if (!response) {
       response = defaultResponse;
     }
@@ -40,7 +40,7 @@ describe("ThrottlingRetryPolicy", () => {
     it("should clone the request", async () => {
       const request = new WebResource();
       const nextPolicy = {
-        sendRequest: (requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        sendRequest: (requestToSend: WebResourceLike): Promise<HttpOperationResponse> => {
           assert(request !== requestToSend);
           return Promise.resolve(defaultResponse);
         }

--- a/test/serviceClientTests.ts
+++ b/test/serviceClientTests.ts
@@ -6,7 +6,7 @@ import { HttpClient } from "../lib/httpClient";
 import { QueryCollectionFormat } from "../lib/queryCollectionFormat";
 import { DictionaryMapper, MapperType, Serializer, Mapper } from "../lib/serializer";
 import { serializeRequestBody, ServiceClient, getOperationArgumentValueFromParameterPath } from "../lib/serviceClient";
-import { WebResource } from "../lib/webResource";
+import { WebResourceLike, WebResource } from "../lib/webResource";
 import { OperationArguments, HttpHeaders, deserializationPolicy, RestResponse, isNode } from "../lib/msRest";
 import { ParameterPath } from "../lib/operationParameter";
 
@@ -18,7 +18,7 @@ describe("ServiceClient", function () {
       "unrelated": "42"
     };
 
-    let request: WebResource;
+    let request: WebResourceLike;
     const client = new ServiceClient(undefined, {
       httpClient: {
         sendRequest: req => {
@@ -74,7 +74,7 @@ describe("ServiceClient", function () {
   });
 
   it("responses should not show the _response property when serializing", async function () {
-    let request: WebResource;
+    let request: WebResourceLike;
     const client = new ServiceClient(undefined, {
       httpClient: {
         sendRequest: req => {
@@ -104,7 +104,7 @@ describe("ServiceClient", function () {
   it("should serialize collection:multi query parameters", async function () {
     const expected = "?q=1&q=2&q=3";
 
-    let request: WebResource;
+    let request: WebResourceLike;
     const client = new ServiceClient(undefined, {
       httpClient: {
         sendRequest: req => {
@@ -152,7 +152,7 @@ describe("ServiceClient", function () {
   });
 
   it("should apply withCredentials to requests", async function () {
-    let request: WebResource;
+    let request: WebResourceLike;
     const httpClient: HttpClient = {
       sendRequest: req => {
         request = req;
@@ -192,7 +192,7 @@ describe("ServiceClient", function () {
   });
 
   it("should deserialize response bodies", async function () {
-    let request: WebResource;
+    let request: WebResourceLike;
     const httpClient: HttpClient = {
       sendRequest: req => {
         request = req;
@@ -233,7 +233,7 @@ describe("ServiceClient", function () {
 
   it("should use userAgent header name value from options", async function () {
     const httpClient: HttpClient = {
-      sendRequest: (request: WebResource) => {
+      sendRequest: (request: WebResourceLike) => {
         return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
       }
     };
@@ -259,7 +259,7 @@ describe("ServiceClient", function () {
 
   it("should use userAgent header name function from options", async function () {
     const httpClient: HttpClient = {
-      sendRequest: (request: WebResource) => {
+      sendRequest: (request: WebResourceLike) => {
         return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
       }
     };
@@ -285,7 +285,7 @@ describe("ServiceClient", function () {
 
   it("should use userAgent string from options", async function () {
     const httpClient: HttpClient = {
-      sendRequest: (request: WebResource) => {
+      sendRequest: (request: WebResourceLike) => {
         return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
       }
     };
@@ -310,7 +310,7 @@ describe("ServiceClient", function () {
 
   it("should use userAgent function from options that appends to defaultUserAgent", async function () {
     const httpClient: HttpClient = {
-      sendRequest: (request: WebResource) => {
+      sendRequest: (request: WebResourceLike) => {
         return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
       }
     };
@@ -338,7 +338,7 @@ describe("ServiceClient", function () {
 
   it("should use userAgent function from options that ignores defaultUserAgent", async function () {
     const httpClient: HttpClient = {
-      sendRequest: (request: WebResource) => {
+      sendRequest: (request: WebResourceLike) => {
         return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
       }
     };


### PR DESCRIPTION
To align with @azure/core-http (see https://github.com/Azure/azure-sdk-for-js/pull/7873) this change widens public interfaces referencing WebResource and HttpHeaders to use interfaces instead. This should prevent future compatibility breaks.

As part of this change I had to do some minor cleanup to the rollup config to avoid a Windows build break.