### PR TITLE
Use Node 10 when building autorest.typescript to avoid Gulp issue

### DIFF
--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -78,7 +78,7 @@ jobs:
       targetPath: $(System.DefaultWorkingDirectory)
   - script: 'mkdir -p $(tempDirectory)'
     displayName: 'mkdir -p $(tempDirectory)'
-  - script: 'git clone https://github.com/Azure/autorest.typescript.git autorest.typescript --recursive --depth 1'
+  - script: 'git clone --single-branch -b v4x https://github.com/Azure/autorest.typescript.git autorest.typescript --recursive --depth 1'
     workingDirectory: $(tempDirectory)
     displayName: "clone autorest.typescript"
   - script: 'npm install $(Build.SourcesDirectory)/$(msRestJsPackageName)'

--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -81,12 +81,12 @@ jobs:
   - script: 'git clone --single-branch -b v4x https://github.com/Azure/autorest.typescript.git autorest.typescript --recursive --depth 1'
     workingDirectory: $(tempDirectory)
     displayName: "clone autorest.typescript"
-  - script: 'npm install $(Build.SourcesDirectory)/$(msRestJsPackageName)'
+  - script: 'npm install $(System.DefaultWorkingDirectory)/$(msRestJsPackageName)'
     workingDirectory: $(repoDir)
     displayName: 'npm install @azure/ms-rest-js'
-  - script: 'npm install $(Build.SourcesDirectory)/$(msRestAzureJsPackageName)'
+  - script: 'npm install $(System.DefaultWorkingDirectory)/$(msRestAzureJsPackageName)'
     workingDirectory: $(repoDir)
-    displayName: 'npm install @azure/ms-rest-azure-js' 
+    displayName: 'npm install @azure/ms-rest-azure-js'
   - script: 'cat package.json'
     workingDirectory: $(repoDir)
     displayName: "debug"

--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -81,12 +81,12 @@ jobs:
   - script: 'git clone https://github.com/Azure/autorest.typescript.git autorest.typescript --recursive --depth 1'
     workingDirectory: $(tempDirectory)
     displayName: "clone autorest.typescript"
-  - script: 'npm install $(Build.SourcesDirectory)/$(msRestAzureJsPackageName)'
-    workingDirectory: $(repoDir)
-    displayName: 'npm install @azure/ms-rest-azure-js'
   - script: 'npm install $(Build.SourcesDirectory)/$(msRestJsPackageName)'
     workingDirectory: $(repoDir)
     displayName: 'npm install @azure/ms-rest-js'
+  - script: 'npm install $(Build.SourcesDirectory)/$(msRestAzureJsPackageName)'
+    workingDirectory: $(repoDir)
+    displayName: 'npm install @azure/ms-rest-azure-js' 
   - script: 'cat package.json'
     workingDirectory: $(repoDir)
     displayName: "debug"

--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -38,7 +38,7 @@ jobs:
   - script: 'git clone https://github.com/Azure/ms-rest-azure-js.git ms-rest-azure-js --depth 1'
     workingDirectory: $(tempDirectory)
     displayName: "clone ms-rest-azure-js"
-  - script: 'npm install $(Build.SourcesDirectory)/$(msRestJsPackageName)'
+  - script: 'npm install --no-save $(Build.SourcesDirectory)/$(msRestJsPackageName)'
     workingDirectory: $(repoDir)
     displayName: 'npm install @azure/ms-rest-js'
   - script: 'npm pack'

--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -63,6 +63,11 @@ jobs:
   variables:
     repoDir: '$(tempDirectory)/autorest.typescript'
   steps:
+   # Autorest appears to use a version of gulp that doesn't yet work with node 12.x: https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 10.x
+    displayName: Use Node.js 10
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: $(artifactName)


### PR DESCRIPTION
This change forces the `autorest.typescript` dependent project build to use Node 10 because there's an issue with Gulp when running on Node 12 that causes this error to be thrown after running `npm install`:

```
> @microsoft.azure/autorest.typescript@5.0.2 prepare /home/vsts/work/1/.tmp/autorest.typescript
> gulp install_common && gulp build

fs.js:35
} = primordials;
    ^

[ReferenceError: primordials is not defined]
```