### PR TITLE
Make sure parsed body is an array when expecting Sequence

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 - Replace public usage of `RequestPolicyOptions` to an interface `RequestPolicyOptionsLike` to avoid compatibility issues with private members.
 - Fix issue with null/undefined values in array and tabs/space delimiter arrays during sendOperationRequest. [PR #390](https://github.com/Azure/ms-rest-js/pull/390)
 
+## 2.0.7 - 2020-04-24
+- Fix in flattenResponse when expecting an array, checking for parsedBody to be an array before proceeding with flattening
+
 ## 2.0.6 - 2020-04-15
 - A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`.  This change was added to improve compatibility between `@azure/core-http` and `@azure/ms-rest-nodeauth`.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,9 +4,7 @@
 - Fixes encoding query parameters in an array before joining them.(PR [#382](https://github.com/Azure/ms-rest-js/pull/382))
 - Replace public usage of `RequestPolicyOptions` to an interface `RequestPolicyOptionsLike` to avoid compatibility issues with private members.
 - Fix issue with null/undefined values in array and tabs/space delimiter arrays during sendOperationRequest. [PR #390](https://github.com/Azure/ms-rest-js/pull/390)
-
-## 2.0.7 - 2020-04-24
-- Fix in flattenResponse when expecting an array, checking for parsedBody to be an array before proceeding with flattening
+- Fix in flattenResponse when expecting an array, checking for parsedBody to be an array before proceeding with flattening. (PR [#385](https://github.com/Azure/ms-rest-js/pull/385))
 
 ## 2.0.6 - 2020-04-15
 - A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`.  This change was added to improve compatibility between `@azure/core-http` and `@azure/ms-rest-nodeauth`.

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -556,7 +556,13 @@ export function flattenResponse(_response: HttpOperationResponse, responseSpec: 
     const modelProperties = typeName === "Composite" && (bodyMapper as CompositeMapper).type.modelProperties || {};
     const isPageableResponse = Object.keys(modelProperties).some(k => modelProperties[k].serializedName === "");
     if (typeName === "Sequence" || isPageableResponse) {
-      const arrayResponse = [...(_response.parsedBody || [])] as RestResponse & any[];
+      // We're expecting a sequece(array) make sure that the response body is in the
+      // correct format, if not make it an empty array []
+      const parsedBody =
+        _response.parsedBody && Array.isArray(_response.parsedBody)
+          ? _response.parsedBody
+          : [];
+      const arrayResponse = [...parsedBody] as RestResponse & any[];
 
       for (const key of Object.keys(modelProperties)) {
         if (modelProperties[key].serializedName) {

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -559,7 +559,7 @@ export function flattenResponse(_response: HttpOperationResponse, responseSpec: 
       // We're expecting a sequece(array) make sure that the response body is in the
       // correct format, if not make it an empty array []
       const parsedBody =
-        _response.parsedBody && Array.isArray(_response.parsedBody)
+        Array.isArray(_response.parsedBody)
           ? _response.parsedBody
           : [];
       const arrayResponse = [...parsedBody] as RestResponse & any[];

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -55,12 +55,12 @@ export const Constants = {
       POST: "POST",
       MERGE: "MERGE",
       HEAD: "HEAD",
-      PATCH: "PATCH",
+      PATCH: "PATCH"
     },
 
     StatusCodes: {
-      TooManyRequests: 429,
-    },
+      TooManyRequests: 429
+    }
   },
 
   /**
@@ -93,6 +93,6 @@ export const Constants = {
      * @const
      * @type {string}
      */
-    USER_AGENT: "User-Agent",
-  },
+    USER_AGENT: "User-Agent"
+  }
 };

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -55,12 +55,12 @@ export const Constants = {
       POST: "POST",
       MERGE: "MERGE",
       HEAD: "HEAD",
-      PATCH: "PATCH"
+      PATCH: "PATCH",
     },
 
     StatusCodes: {
-      TooManyRequests: 429
-    }
+      TooManyRequests: 429,
+    },
   },
 
   /**
@@ -93,6 +93,6 @@ export const Constants = {
      * @const
      * @type {string}
      */
-    USER_AGENT: "User-Agent"
-  }
+    USER_AGENT: "User-Agent",
+  },
 };

--- a/test/serviceClientTests.ts
+++ b/test/serviceClientTests.ts
@@ -219,6 +219,79 @@ describe("ServiceClient", function () {
     assert.deepStrictEqual(res.slice(), [1, 2, 3]);
   });
 
+  it("should deserialize response bodies with undefined array", async function () {
+    let request: WebResourceLike;
+    const httpClient: HttpClient = {
+      sendRequest: (req) => {
+        request = req;
+        return Promise.resolve({
+          request,
+          status: 200,
+          headers: new HttpHeaders(),
+          bodyAsText: JSON.stringify({ nextLink: "mockLink" }),
+        });
+      },
+    };
+
+    const client1 = new ServiceClient(undefined, {
+      httpClient,
+      requestPolicyFactories: [deserializationPolicy()],
+    });
+
+    const res = (await client1.sendOperationRequest(
+      {},
+      {
+        serializer: new Serializer(),
+        httpMethod: "GET",
+        baseUrl: "httpbin.org",
+        responses: {
+          "200": {
+            bodyMapper: {
+              type: {
+                name: "Composite",
+                modelProperties: {
+                  value: {
+                    serializedName: "",
+                    type: {
+                      name: "Sequence",
+                      element: {
+                        type: { name: "String" },
+                      },
+                    },
+                  },
+                  nextLink: {
+                    serializedName: "nextLink",
+                    type: { name: "String" },
+                  },
+                },
+              },
+            },
+          },
+          default: {
+            bodyMapper: {
+              serializedName: "ErrorResponse",
+              type: {
+                name: "Composite",
+                className: "ErrorResponse",
+                modelProperties: {
+                  code: { serializedName: "code", type: { name: "String" } },
+                  message: {
+                    serializedName: "message",
+                    type: { name: "String" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+    )) as any;
+
+    assert.strictEqual(res._response.status, 200);
+    assert.deepStrictEqual(res.nextLink, "mockLink");
+    assert.deepStrictEqual(res, []);
+  });
+
   it("should use userAgent header name value from options", async function () {
     const httpClient: HttpClient = {
       sendRequest: (request: WebResourceLike) => {


### PR DESCRIPTION
Issue:

When an operation spec defines that a response should be of type Sequence (array) but the service actually returns null/undefined instead of an empty list, we end up crashing with the following error as the empty response body gets deserialized as {}
```
TypeError: (_response.parsedBody || []).slice is not a function at flattenResponse (/mnt/c/Users/jepri/scratch/node_modules/@azure/ms-rest-js/dist/msRest.node.js:3518:62)
at /mnt/c/Users/jepri/scratch/node_modules/@azure/ms-rest-js/dist/msRest.node.js:3353:47
at at process._tickCallback (internal/process/next_tick.js:189:7)
```

See Azure/azure-sdk-for-js/issues/8445

**Note**:  `[...(_response.parsedBody || [])]` gets compiled into `(_response.parsedBody || []).slice()`.

Fix:
When we are expecting an array, make sure we have one before proceeding