### PR TITLE
[1.x] Make sure parsed body is an array when expecting Sequence

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.15 - 2020-04-28
+- Fix in flattenResponse when expecting an array, checking for parsedBody to be an array before proceeding with flattening
+
 ## 1.8.14 - 2019-12-10
 - Fixed an issue where making many requests will cause Node.js to reach the memory allocation limit ([PR #](https://github.com/Azure/ms-rest-js/pull/375)).
 

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -551,7 +551,13 @@ export function flattenResponse(_response: HttpOperationResponse, responseSpec: 
     const modelProperties = typeName === "Composite" && (bodyMapper as CompositeMapper).type.modelProperties || {};
     const isPageableResponse = Object.keys(modelProperties).some(k => modelProperties[k].serializedName === "");
     if (typeName === "Sequence" || isPageableResponse) {
-      const arrayResponse = [...(_response.parsedBody || [])] as RestResponse & any[];
+      // We're expecting a sequece(array) make sure that the response body is in the
+      // correct format, if not make it an empty array []
+      const parsedBody =
+        Array.isArray(_response.parsedBody)
+          ? _response.parsedBody
+          : [];
+      const arrayResponse = [...parsedBody] as RestResponse & any[];
 
       for (const key of Object.keys(modelProperties)) {
         if (modelProperties[key].serializedName) {

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -551,7 +551,7 @@ export function flattenResponse(_response: HttpOperationResponse, responseSpec: 
     const modelProperties = typeName === "Composite" && (bodyMapper as CompositeMapper).type.modelProperties || {};
     const isPageableResponse = Object.keys(modelProperties).some(k => modelProperties[k].serializedName === "");
     if (typeName === "Sequence" || isPageableResponse) {
-      // We're expecting a sequece(array) make sure that the response body is in the
+      // We're expecting a sequence(array) make sure that the response body is in the
       // correct format, if not make it an empty array []
       const parsedBody =
         Array.isArray(_response.parsedBody)

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.8.14",
+  msRestVersion: "1.8.15",
 
   /**
    * Specifies HTTP.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ms-rest-js",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.8.14",
+  "version": "1.8.15",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/defaultHttpClientTests.ts
+++ b/test/defaultHttpClientTests.ts
@@ -143,8 +143,8 @@ describe("defaultHttpClient", function () {
     };
 
     it("for simple bodies", async function () {
-      httpMock.post("/fileupload", async (_url, _method, body) => {
-        return { status: 251, body: body, headers: { "Content-Length": "200" } };
+      httpMock.post("/fileupload", async (_url, _method) => {
+        return { status: 251, body: {}, headers: { "Content-Length": "200" } };
       });
 
       const upload: Notified = { notified: false };


### PR DESCRIPTION
Issue:

When an operation spec defines that a response should be of type Sequence (array) but the service actually returns null/undefined instead of an empty list, we end up crashing with the following error as the empty response body gets deserialized as {}
```
TypeError: (_response.parsedBody || []).slice is not a function at flattenResponse (/mnt/c/Users/jepri/scratch/node_modules/@azure/ms-rest-js/dist/msRest.node.js:3518:62)
at /mnt/c/Users/jepri/scratch/node_modules/@azure/ms-rest-js/dist/msRest.node.js:3353:47
at at process._tickCallback (internal/process/next_tick.js:189:7)
```

See Azure/azure-sdk-for-js/issues/8445

**Note**:  `[...(_response.parsedBody || [])]` gets compiled into `(_response.parsedBody || []).slice()`.

Fix:
When we are expecting an array, make sure we have one before proceeding