### PR TITLE
Code to load proxyPolicy browser js

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.0.8 - 2020-07-23
+- [BugFix] - Fixed loading of proxyPolicy.browser.js in the HTML files.(PR [#397](https://github.com/Azure/ms-rest-js/pull/397))
 
 ## 2.0.7 - 2020-04-30
 - Fixes encoding query parameters in an array before joining them.(PR [#382](https://github.com/Azure/ms-rest-js/pull/382))

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.0.7",
+  msRestVersion: "2.0.8",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "browser": {
     "./es/lib/policies/msRestUserAgentPolicy.js": "./es/lib/policies/msRestUserAgentPolicy.browser.js",
+    "./es/lib/policies/proxyPolicy.js": "./es/lib/policies/proxyPolicy.browser.js",
     "./es/lib/util/base64.js": "./es/lib/util/base64.browser.js",
     "./es/lib/util/xml.js": "./es/lib/util/xml.browser.js",
     "./es/lib/defaultHttpClient.js": "./es/lib/defaultHttpClient.browser.js"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
This PR is to fix issue https://github.com/Azure/ms-rest-js/issues/396. The proxyPolicy.browser.js file is not loading correctly even in HTML samples. This PR will fix it. I have tested it with the sample provided in the issue.

@ramya-rao-a Please review and approve.