### PR TITLE
Port WebResource keepAlive setting from 2.x to 1.x

### DIFF
--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -28,6 +28,13 @@ axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => ({
   method: (config.method as Method) && (config.method as Method).toUpperCase() as Method
 }));
 
+// keepalive agents are reused across instances to provide maximum socket reuse for
+// outbound requests
+const keepaliveAgents = {
+  http: new http.Agent({keepAlive: true}),
+  https: new https.Agent({keepAlive: true}),
+}
+
 /**
  * A HttpClient implementation that uses axios to send HTTP requests.
  */
@@ -154,7 +161,11 @@ export class AxiosHttpClient implements HttpClient {
         } else {
           config.httpAgent = agent.agent;
         }
+      } else if (httpRequest.keepAlive) {
+        config.httpAgent = keepaliveAgents.http;
+        config.httpsAgent = keepaliveAgents.https;
       }
+
       res = await axiosInstance.request(config);
     } catch (err) {
       if (err instanceof axios.Cancel) {

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -33,7 +33,7 @@ axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => ({
 const keepaliveAgents = {
   http: new http.Agent({keepAlive: true}),
   https: new https.Agent({keepAlive: true}),
-}
+};
 
 /**
  * A HttpClient implementation that uses axios to send HTTP requests.

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.8.15",
+  msRestVersion: "1.8.16",
 
   /**
    * Specifies HTTP.

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -66,6 +66,7 @@ export class WebResource {
   withCredentials: boolean;
   timeout: number;
   proxySettings?: ProxySettings;
+  keepAlive?: boolean;
 
   abortSignal?: AbortSignalLike;
 
@@ -87,7 +88,8 @@ export class WebResource {
     timeout?: number,
     onUploadProgress?: (progress: TransferProgressEvent) => void,
     onDownloadProgress?: (progress: TransferProgressEvent) => void,
-    proxySettings?: ProxySettings) {
+    proxySettings?: ProxySettings,
+    keepAlive?: boolean) {
 
     this.streamResponseBody = streamResponseBody;
     this.url = url || "";
@@ -102,6 +104,7 @@ export class WebResource {
     this.onUploadProgress = onUploadProgress;
     this.onDownloadProgress = onDownloadProgress;
     this.proxySettings = proxySettings;
+    this.keepAlive = keepAlive;
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.8.15",
+  "version": "1.8.16",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
This port will allow the Bot Framework SDK to better support customer bots with high traffic.

For some more context, the Bot Framework JS SDK currently makes heavy use of the `@azure/ms-rest-js` library. Due to requirements around backwards compatibility, we are tied to the `1.x` branch (currently `v1.8.15`). In particular, we support customization of the underlying Axios HTTP client. In effect, this means that upgrading to the `2.x` version of this library is currently not tenable.

In order to better support customers with high traffic bots running on Azure, we need to leverage HTTP keepalive as much as possible. The `2.x` version of this library added a `keepAlive` setting to the `WebResource` class (though, to be fair, exposing an `agent` parameter directly might be even more friendly). This PR ports this functionality back to the `1.x` branch and uses a shared pair of http/https agents so that HTTP connections can be shared across instances of the HTTP client (similar to the shared axios instance).

With this change, the Bot Framework SDK can support enabling `keepAlive` using a request policy:

```typescript
import { HttpOperationResponse, RequestPolicy, ServiceClientOptions, WebResource } from '@azure/ms-rest-js';

const options: ServiceClientOptions = {};

const create = (nextPolicy: RequestPolicy): RequestPolicy => {
    const sendRequest = (httpRequest: WebResource): Promise<HttpOperationResponse> => {
        httpRequest.keepAlive = true;
        return nextPolicy.sendRequest(httpRequest);
    };

    return { sendRequest };
};

options.requestPolicyFactories = (factories) => [...factories, { create }];
```

[Here is a sample issue on the Bot Framework SDK repo that illustrates that this is a pain point for current users](https://github.com/microsoft/botbuilder-js/issues/183).

I'm happy to put in more legwork here if this change seems reasonable.

Moreover, if supporting a `ServiceClientOptions.agentSettings` option seems reasonable I am happy to work on that on both the `2.x` and `1.x` branches. I think this could be a really useful feature because it would allow users of the library to have complete control over the HTTP(S) Agent used for outbound requests. In fact, I was 85% done writing that code on the `1.x` branch before I realized I ought to mimic the behavior added to the `2.x` release first.