### PR TITLE
Fix a build error involving xml2js

### DIFF
--- a/lib/util/xml.ts
+++ b/lib/util/xml.ts
@@ -5,8 +5,6 @@ import * as xml2js from "xml2js";
 
 export function stringifyXML(obj: any, opts?: { rootName?: string }) {
   const builder = new xml2js.Builder({
-    explicitArray: false,
-    explicitCharkey: false,
     rootName: (opts || {}).rootName,
     renderOpts: {
       pretty: false


### PR DESCRIPTION
Currently building master fails with the following error:
```lib/util/xml.ts:8:5 - error TS2345: Argument of type '{ explicitArray: boolean; explicitCharkey: boolean; rootName: string | undefined; renderOpts: { pretty: false; }; }' is not assignable to parameter of type 'BuilderOptions'.
  Object literal may only specify known properties, and 'explicitArray' does not exist in type 'BuilderOptions'.

8     explicitArray: false,
      ~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```
because of new changes in `@types/xml2js`. This PR fixes the issue by removing unnecessary arguments from the builder options that were not used anywhere in the constructor. Tests succeeds locally.