### PR TITLE
Add TokenCredential adapter

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2.1.1 - 2021-01-22
+- Add support for @azure/core-auth's TokenCredential (PR [#410](https://github.com/Azure/ms-rest-js/pull/410))
+
 ## 2.1.0 - 2020-10-08
 - Add support for custom http/https agent (PR [#403](https://github.com/Azure/ms-rest-js/pull/403))
 - Fix WebResource clone to include extra settings (Issue [#405](https://github.com/Azure/ms-rest-js/issue/403))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.1.1 - 2021-01-22
+## 2.2.0 - 2021-01-22
 - Add support for @azure/core-auth's TokenCredential (PR [#410](https://github.com/Azure/ms-rest-js/pull/410))
 
 ## 2.1.0 - 2020-10-08

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -11,7 +11,7 @@ import { TokenResponse } from "@azure/ms-rest-nodeauth/dist/lib/credentials/toke
 const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
 
 /**
- * This class provides a simple extension to use {@link TokenCredential} from com.azure:azure-identity library to
+ * This class provides a simple extension to use {@link TokenCredential} from `@azure/identity` library to
  * use with legacy Azure SDKs that accept {@link ServiceClientCredentials} family of credentials for authentication.
  */
 export class AzureIdentityCredentialAdapter

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -36,7 +36,7 @@ export class AzureIdentityCredentialAdapter
       };
       return result;
     } else {
-        throw new Error("Could find token for scope");
+      throw new Error("Could find token for scope");
     }
   }
 

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { ServiceClientCredentials } from "./serviceClientCredentials";
+import { Constants as MSRestConstants } from "../util/constants";
+import { WebResource } from "../webResource";
+
+import { TokenCredential } from "@azure/core-auth";
+import { TokenResponse } from "@azure/ms-rest-nodeauth/dist/lib/credentials/tokenClientCredentials";
+
+const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
+
+/**
+ * This class provides a simple extension to use {@link TokenCredential} from com.azure:azure-identity library to
+ * use with legacy Azure SDKs that accept {@link ServiceClientCredentials} family of credentials for authentication.
+ */
+export class AzureIdentityCredentialAdapter
+  implements ServiceClientCredentials {
+  private azureTokenCredential: TokenCredential;
+  private scopes: string | string[];
+  constructor(
+    azureTokenCredential: TokenCredential,
+    scopes: string | string[] = "https://management.azure.com/.default"
+  ) {
+    this.azureTokenCredential = azureTokenCredential;
+    this.scopes = scopes;
+  }
+
+  public async getToken(): Promise<TokenResponse> {
+    const accessToken = await this.azureTokenCredential.getToken(this.scopes);
+    if (accessToken !== null) {
+      const result: TokenResponse = {
+        accessToken: accessToken.token,
+        tokenType: DEFAULT_AUTHORIZATION_SCHEME,
+        expiresOn: accessToken.expiresOnTimestamp,
+      };
+      return result;
+    } else {
+        throw new Error("Could find token for scope");
+    }
+  }
+
+  public async signRequest(webResource: WebResource) {
+    const tokenResponse = await this.getToken();
+    webResource.headers.set(
+      MSRestConstants.HeaderConstants.AUTHORIZATION,
+      `${tokenResponse.tokenType} ${tokenResponse.accessToken}`
+    );
+    return Promise.resolve(webResource);
+  }
+}

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -6,7 +6,7 @@ import { Constants as MSRestConstants } from "../util/constants";
 import { WebResource } from "../webResource";
 
 import { TokenCredential } from "@azure/core-auth";
-import { TokenResponse } from "@azure/ms-rest-nodeauth/dist/lib/credentials/tokenClientCredentials";
+import { TokenResponse } from "./tokenResponse";
 
 const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
 

--- a/lib/credentials/tokenResponse.ts
+++ b/lib/credentials/tokenResponse.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+/**
+ * TokenResponse is defined in `@azure/ms-rest-nodeauth` and is copied here to not
+ * add an unnecessary dependency.
+ */
+export interface TokenResponse {
+    readonly tokenType: string;
+    readonly accessToken: string;
+    readonly [x: string]: any;
+  }

--- a/lib/credentials/tokenResponse.ts
+++ b/lib/credentials/tokenResponse.ts
@@ -6,7 +6,7 @@
  * add an unnecessary dependency.
  */
 export interface TokenResponse {
-    readonly tokenType: string;
-    readonly accessToken: string;
-    readonly [x: string]: any;
-  }
+  readonly tokenType: string;
+  readonly accessToken: string;
+  readonly [x: string]: any;
+}

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 import { DefaultHttpClient } from "./defaultHttpClient";
 import { HttpClient } from "./httpClient";
@@ -30,6 +31,7 @@ import { agentPolicy } from "./policies/agentPolicy";
 import { proxyPolicy, getDefaultProxySettings } from "./policies/proxyPolicy";
 import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 import { Agent } from "http";
+import { AzureIdentityCredentialAdapter } from "./credentials/azureIdentityTokenCredentialAdapter";
 
 
 /**
@@ -148,12 +150,20 @@ export class ServiceClient {
    * @param {ServiceClientCredentials} [credentials] The credentials object used for authentication.
    * @param {ServiceClientOptions} [options] The service client options that govern the behavior of the client.
    */
-  constructor(credentials?: ServiceClientCredentials, options?: ServiceClientOptions) {
+  constructor(credentials?: ServiceClientCredentials | TokenCredential, options?: ServiceClientOptions) {
     if (!options) {
       options = {};
     }
 
-    if (credentials && !credentials.signRequest) {
+    let serviceClientCredentials: ServiceClientCredentials | undefined;
+    if (isTokenCredential(credentials)) {
+      serviceClientCredentials = new AzureIdentityCredentialAdapter(credentials);
+    } else {
+      serviceClientCredentials = credentials;
+    }
+
+
+    if (serviceClientCredentials && !serviceClientCredentials.signRequest) {
       throw new Error("credentials argument needs to implement signRequest method");
     }
 
@@ -165,7 +175,7 @@ export class ServiceClient {
     if (Array.isArray(options.requestPolicyFactories)) {
       requestPolicyFactories = options.requestPolicyFactories;
     } else {
-      requestPolicyFactories = createDefaultRequestPolicyFactories(credentials, options);
+      requestPolicyFactories = createDefaultRequestPolicyFactories(serviceClientCredentials, options);
       if (options.requestPolicyFactories) {
         const newRequestPolicyFactories: void | RequestPolicyFactory[] = options.requestPolicyFactories(requestPolicyFactories);
         if (newRequestPolicyFactories) {

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.1.0",
+  msRestVersion: "2.2.0",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "license": "MIT",
   "dependencies": {
     "@azure/core-auth": "^1.1.4",
-    "@azure/ms-rest-nodeauth": "^3.0.6",
     "@types/node-fetch": "^2.3.7",
     "@types/tunnel": "0.0.1",
     "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@azure/core-auth": "1.1.4",
+    "@azure/core-auth": "^1.1.4",
     "@azure/ms-rest-nodeauth": "^3.0.6",
     "@types/node-fetch": "^2.3.7",
     "@types/tunnel": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@azure/core-auth": "1.1.4",
+    "@azure/ms-rest-nodeauth": "^3.0.6",
     "@types/node-fetch": "^2.3.7",
     "@types/tunnel": "0.0.1",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
Enables using identity's TokenCredential using an adapter that converts to `ServiceClientCredentials`.

TODO
- make a release.