### PR TITLE
Adding support for @azure/identity in v1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 1.9.1 - UNRELEASED
+## 1.10.0 - UNRELEASED
+- Add support for @azure/core-auth's TokenCredential
+
+## 1.9.1 - 2021-01-07
 - Upgrade axios dependency to fix vulnerability (PR [#407](https://github.com/Azure/ms-rest-js/pull/407))
 
 ## 1.9.0 - 2020-10-08

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 1.10.0 - UNRELEASED
-- Add support for @azure/core-auth's TokenCredential
+## 1.10.0 - 2021-02-02
+- Add support for @azure/core-auth's TokenCredential (PR [#418](https://github.com/Azure/ms-rest-js/pull/418))
 
 ## 1.9.1 - 2021-01-07
 - Upgrade axios dependency to fix vulnerability (PR [#407](https://github.com/Azure/ms-rest-js/pull/407))

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { ServiceClientCredentials } from "./serviceClientCredentials";
+import { Constants as MSRestConstants } from "../util/constants";
+import { WebResource } from "../webResource";
+
+import { TokenCredential } from "@azure/core-auth";
+import { TokenResponse } from "./tokenResponse";
+
+const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
+
+/**
+ * This class provides a simple extension to use {@link TokenCredential} from `@azure/identity` library to
+ * use with legacy Azure SDKs that accept {@link ServiceClientCredentials} family of credentials for authentication.
+ */
+export class AzureIdentityCredentialAdapter
+  implements ServiceClientCredentials {
+  private azureTokenCredential: TokenCredential;
+  private scopes: string | string[];
+  constructor(
+    azureTokenCredential: TokenCredential,
+    scopes: string | string[] = "https://management.azure.com/.default"
+  ) {
+    this.azureTokenCredential = azureTokenCredential;
+    this.scopes = scopes;
+  }
+
+  public async getToken(): Promise<TokenResponse> {
+    const accessToken = await this.azureTokenCredential.getToken(this.scopes);
+    if (accessToken !== null) {
+      const result: TokenResponse = {
+        accessToken: accessToken.token,
+        tokenType: DEFAULT_AUTHORIZATION_SCHEME,
+        expiresOn: accessToken.expiresOnTimestamp,
+      };
+      return result;
+    } else {
+      throw new Error("Could find token for scope");
+    }
+  }
+
+  public async signRequest(webResource: WebResource) {
+    const tokenResponse = await this.getToken();
+    webResource.headers.set(
+      MSRestConstants.HeaderConstants.AUTHORIZATION,
+      `${tokenResponse.tokenType} ${tokenResponse.accessToken}`
+    );
+    return Promise.resolve(webResource);
+  }
+}

--- a/lib/credentials/tokenResponse.ts
+++ b/lib/credentials/tokenResponse.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+/**
+ * TokenResponse is defined in `@azure/ms-rest-nodeauth` and is copied here to not
+ * add an unnecessary dependency.
+ */
+export interface TokenResponse {
+    readonly tokenType: string;
+    readonly accessToken: string;
+    readonly [x: string]: any;
+  }

--- a/lib/credentials/tokenResponse.ts
+++ b/lib/credentials/tokenResponse.ts
@@ -6,7 +6,7 @@
  * add an unnecessary dependency.
  */
 export interface TokenResponse {
-    readonly tokenType: string;
-    readonly accessToken: string;
-    readonly [x: string]: any;
-  }
+  readonly tokenType: string;
+  readonly accessToken: string;
+  readonly [x: string]: any;
+}

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.9.1",
+  msRestVersion: "1.10.0",
 
   /**
    * Specifies HTTP.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,44 @@
 {
   "name": "@azure/ms-rest-js",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.2.tgz",
+      "integrity": "sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.4.tgz",
+      "integrity": "sha512-+j1embyH1jqf04AIfJPdLafd5SC1y6z1Jz4i+USR1XkTp6KM8P5u4/AjmWMVoEQdM/M29PJcRDZcCEWjK9S1bw==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
+      }
+    },
     "@azure/logger-js": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@azure/logger-js/-/logger-js-1.3.2.tgz",
@@ -9471,9 +9506,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",
@@ -60,6 +60,7 @@
     "xml2js": "^0.4.19"
   },
   "devDependencies": {
+    "@azure/core-auth": "^1.1.4",
     "@azure/logger-js": "^1.0.2",
     "@ts-common/azure-js-dev-tools": "^15.2.0",
     "@types/chai": "^4.1.7",
@@ -112,7 +113,7 @@
     "ts-node": "^7.0.0",
     "tslint": "^5.16.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^3.4.5",
+    "typescript": "^3.6.0",
     "uglify-js": "^3.4.9",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.1.2",


### PR DESCRIPTION
Enables using identity's TokenCredential using an adapter that converts to `ServiceClientCredentials`. Similar to https://github.com/Azure/ms-rest-js/pull/410.