### PR TITLE
CI should build ms-rest-azure-js after installing ms-rest-js

### DIFF
--- a/.devops/azure-pipelines-test-dependent-projects.yml
+++ b/.devops/azure-pipelines-test-dependent-projects.yml
@@ -43,7 +43,10 @@ jobs:
     displayName: 'npm pack'
   - script: 'npm install $(Build.SourcesDirectory)/$(msRestJsPackageName)'
     workingDirectory: $(repoDir)
-    displayName: 'npm install @azure/ms-rest-js'
+    displayName: 'npm install @azure/ms-rest-js from artifacts'
+  - script: 'npm run build'
+    workingDirectory: $(repoDir)
+    displayName: 'npm run build'
   - script: 'npm run test'
     workingDirectory: $(repoDir)
     displayName: "npm run test"


### PR DESCRIPTION
`npm run test` didn't surface some build errors