### PR TITLE
[1.x] Revert moving @types/tunnel into devDependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+
+## 1.12.0 - 2021-02-05
+- Revert moving @types/tunnel dependencies into devDependencies. It breaks dependent projects (Issue [#431](https://github.com/Azure/ms-rest-js/issues/431)).
+
 ## 1.11.0 - 2021-02-05
 - Moving @types/tunnel dependencies into devDependencies to avoid pulling in @types/node indirectly. Developers should install @types/node based on the platform they are targeting.
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.11.0",
+  msRestVersion: "1.12.0",
 
   /**
    * Specifies HTTP.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ms-rest-js",
-  "version": "1.10.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ms-rest-js",
-  "version": "1.11.0",
+  "version": "1.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -572,7 +572,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
       "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       },
@@ -580,8 +579,7 @@
         "@types/node": {
           "version": "12.12.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-          "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
-          "dev": true
+          "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",
@@ -50,6 +50,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/tunnel": "0.0.0",
     "axios": "^0.21.1",
     "form-data": "^2.3.2",
     "tough-cookie": "^2.4.3",
@@ -72,7 +73,6 @@
     "@types/semver": "^5.5.0",
     "@types/sinon": "^5.0.6",
     "@types/tough-cookie": "^2.3.3",
-    "@types/tunnel": "0.0.0",
     "@types/uuid": "^3.4.4",
     "@types/webpack": "^4.4.13",
     "@types/webpack-dev-middleware": "^2.0.2",


### PR DESCRIPTION
It is actually required in our public api surface.