### PR TITLE
Stop depending on tunnel.HttpsOverHttpsOptions for createTunnel()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.11.1 - 2021-02-10
+- Dependent projects of @azure/ms-rest-js no longer need to have a dev dependency on @types/tunnel. (Issue [#431](https://github.com/Azure/ms-rest-js/issues/431))
+
 ## 1.11.0 - 2021-02-05
 - Moving @types/tunnel dependencies into devDependencies to avoid pulling in @types/node indirectly. Developers should install @types/node based on the platform they are targeting.
 

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -282,7 +282,40 @@ export function createProxyAgent(requestUrl: string, proxySettings: ProxySetting
   return proxyAgent;
 }
 
-export function createTunnel(isRequestHttps: boolean, isProxyHttps: boolean, tunnelOptions: tunnel.HttpsOverHttpsOptions): http.Agent | https.Agent {
+
+// Duplicate tunnel.HttpsOverHttpsOptions to avoid exporting createTunnel() with dependency on @types/tunnel
+// createIunnel() is only imported by tests.
+interface ProxyOptions {
+  host?: string;
+  port?: number;
+  localAddress?: string;
+  proxyAuth?: string;
+  headers: { [key: string]: any };
+}
+
+interface HttpOptions {
+  maxSockets?: number;
+  proxy?: ProxyOptions;
+}
+
+interface HttpsOverHttpOptions extends HttpOptions {
+  ca?: Buffer[];
+  key?: Buffer;
+  cert?: Buffer;
+}
+
+export interface HttpsProxyOptions extends ProxyOptions {
+  ca?: Buffer[];
+  servername?: string;
+  key?: Buffer;
+  cert?: Buffer;
+}
+
+interface HttpsOverHttpsOptions extends HttpsOverHttpOptions {
+  proxy?: HttpsProxyOptions;
+}
+
+export function createTunnel(isRequestHttps: boolean, isProxyHttps: boolean, tunnelOptions: HttpsOverHttpsOptions): http.Agent | https.Agent {
   if (isRequestHttps && isProxyHttps) {
     return tunnel.httpsOverHttps(tunnelOptions);
   } else if (isRequestHttps && !isProxyHttps) {

--- a/lib/axiosHttpClient.ts
+++ b/lib/axiosHttpClient.ts
@@ -285,33 +285,23 @@ export function createProxyAgent(requestUrl: string, proxySettings: ProxySetting
 
 // Duplicate tunnel.HttpsOverHttpsOptions to avoid exporting createTunnel() with dependency on @types/tunnel
 // createIunnel() is only imported by tests.
-interface ProxyOptions {
+export interface HttpsProxyOptions {
   host?: string;
   port?: number;
   localAddress?: string;
   proxyAuth?: string;
   headers: { [key: string]: any };
-}
-
-interface HttpOptions {
-  maxSockets?: number;
-  proxy?: ProxyOptions;
-}
-
-interface HttpsOverHttpOptions extends HttpOptions {
-  ca?: Buffer[];
-  key?: Buffer;
-  cert?: Buffer;
-}
-
-export interface HttpsProxyOptions extends ProxyOptions {
   ca?: Buffer[];
   servername?: string;
   key?: Buffer;
   cert?: Buffer;
 }
 
-interface HttpsOverHttpsOptions extends HttpsOverHttpOptions {
+interface HttpsOverHttpsOptions {
+  maxSockets?: number;
+  ca?: Buffer[];
+  key?: Buffer;
+  cert?: Buffer;
   proxy?: HttpsProxyOptions;
 }
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "1.11.0",
+  msRestVersion: "1.11.1",
 
   /**
    * Specifies HTTP.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/ms-rest-js",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
by duplicating the interface. `createTunnel()` is only used internally for testing.

Even though we don't exporse it in public API surface, it is causing problem requiring dependent projects to have dev dependency on @types/tunnel.
