### PR TITLE
Add Core AsyncIterator Polyfill to ms-rest-js

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.2.4 - 2021-02-23
-- Added ```@azure/core-asynciterator-polyfill``` package as a dependency. Please refer [Issue #8764](https://github.com/Azure/azure-sdk-for-js/issues/8764) for further details.
+- Added ```@azure/core-asynciterator-polyfill``` package as a dependency. If the SDKs (that have ```ms-rest-js``` dependency) have async iterables, AND if the SDK user uses a node version before 10.x.x, then the code will error out. This polyfill dependency enables the successful execution of such code.
 
 ## 2.2.3 - 2021-02-10
 - Dependent projects of @azure/ms-rest-js no longer need to have a dev dependency on @types/tunnel.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.2.4 - 2021-02-23
+- Added ```@azure/core-asynciterator-polyfill``` package as a dependency. Please refer [Issue #8764](https://github.com/Azure/azure-sdk-for-js/issues/8764) for further details.
+
 ## 2.2.3 - 2021-02-10
 - Dependent projects of @azure/ms-rest-js no longer need to have a dev dependency on @types/tunnel.
 

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -94,3 +94,4 @@ export { ServiceClientCredentials } from "./credentials/serviceClientCredentials
 export { TopicCredentials } from "./credentials/topicCredentials";
 export { DomainCredentials } from "./credentials/domainCredentials";
 export { Authenticator } from "./credentials/credentials";
+import "@azure/core-asynciterator-polyfill";

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.2.3",
+  msRestVersion: "2.2.4",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-auth": "^1.1.4",
     "@types/node-fetch": "^2.3.7",
     "@types/tunnel": "0.0.1",


### PR DESCRIPTION
This is related to Issue https://github.com/Azure/azure-sdk-for-js/issues/8764.  This PR adds the ```core-asynciterator-polyfill``` dependency to the ```ms-rest-js``` package.

@ramya-rao-a Please review and approve.