### PR TITLE
Specify redirect behaviour for indivual requests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,5 @@
 # Changelog
-## 2.5.0 - UNRELEASED
+## 2.5.0 - (2021-05-10)
 
 - Add WebResource.redirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed.
 - Port changes to redirect policy from [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js/pull/11863/files]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.3.1 - UNRELEASED
+- Add WebResource.RedirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed
 
 ## 2.3.0 - 2021-03-29
 - Moving @types dependencies into devdependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 2.3.1 - UNRELEASED
-- Add WebResource.RedirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed
+- Add WebResource.redirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed
 
 ## 2.3.0 - 2021-03-29
 - Moving @types dependencies into devdependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 2.3.1 - UNRELEASED
-- Add WebResource.redirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed
+- Add WebResource.redirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed.
 
 ## 2.3.0 - 2021-03-29
 - Moving @types dependencies into devdependencies

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog
-## 2.3.1 - UNRELEASED
+## 2.5.0 - UNRELEASED
+
 - Add WebResource.redirectLimit: Limit the number of redirects followed for this request. If set to 0, redirects will not be followed.
+- Port changes to redirect policy from [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js/pull/11863/files]
 
 ## 2.4.0 - 2021-04-19
 

--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -130,11 +130,6 @@ export abstract class FetchHttpClient implements HttpClient {
       body = uploadReportStream;
     }
 
-    const redirectInit: Partial<RequestInit> = {};
-    if (httpRequest.redirectLimit !== undefined) {
-      redirectInit.redirect = "manual";
-    }
-
     const platformSpecificRequestInit: Partial<RequestInit> = await this.prepareRequest(
       httpRequest
     );
@@ -144,7 +139,7 @@ export abstract class FetchHttpClient implements HttpClient {
       headers: httpRequest.headers.rawHeaders(),
       method: httpRequest.method,
       signal: abortController.signal,
-      ...redirectInit,
+      redirect: "manual",
       ...platformSpecificRequestInit,
     };
 

--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -161,6 +161,8 @@ export abstract class FetchHttpClient implements HttpClient {
           ? ((response.body as unknown) as NodeJS.ReadableStream)
           : undefined,
         bodyAsText: !httpRequest.streamResponseBody ? await response.text() : undefined,
+        redirected: response.redirected,
+        url: response.url,
       };
 
       const onDownloadProgress = httpRequest.onDownloadProgress;

--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -130,6 +130,11 @@ export abstract class FetchHttpClient implements HttpClient {
       body = uploadReportStream;
     }
 
+    const redirectInit: Partial<RequestInit> = {};
+    if (httpRequest.redirectLimit !== undefined) {
+      redirectInit.redirect = "manual";
+    }
+
     const platformSpecificRequestInit: Partial<RequestInit> = await this.prepareRequest(
       httpRequest
     );
@@ -139,6 +144,7 @@ export abstract class FetchHttpClient implements HttpClient {
       headers: httpRequest.headers.rawHeaders(),
       method: httpRequest.method,
       signal: abortController.signal,
+      ...redirectInit,
       ...platformSpecificRequestInit,
     };
 

--- a/lib/httpOperationResponse.ts
+++ b/lib/httpOperationResponse.ts
@@ -67,6 +67,16 @@ export interface HttpOperationResponse extends HttpResponse {
    * Always undefined in the browser.
    */
   readableStreamBody?: NodeJS.ReadableStream;
+
+  /**
+   * The redirected property indicates whether the response is the result of a request which was redirected.
+   */
+  redirected?: boolean;
+
+  /**
+   * The url property contains the URL of the response. The value will be the final URL obtained after any redirects.
+   */
+  url?: string;
 }
 
 /**

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -60,8 +60,19 @@ function handleRedirect(
 
     return policy._nextPolicy
       .sendRequest(request)
-      .then((res) => handleRedirect(policy, res, currentRetries + 1));
+      .then((res) => handleRedirect(policy, res, currentRetries + 1))
+      .then((res) => recordRedirect(res, request.url));
   }
 
   return Promise.resolve(response);
 }
+
+function recordRedirect(response: HttpOperationResponse, redirect: string): HttpOperationResponse {
+  // only record the deepest/last redirect
+  if (!response.redirected) {
+    response.redirected = true;
+    response.url = redirect;
+  }
+  return response;
+}
+

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -44,16 +44,17 @@ function handleRedirect(
   const locationHeader = response.headers.get("location");
   if (
     locationHeader &&
-    (status === 300 || status === 307 || (status === 303 && request.method === "POST")) &&
-    (!policy.maxRetries || currentRetries < policy.maxRetries)
+    (status === 300 || status === 302 || status === 307 || (status === 303 && request.method === "POST")) &&
+    (currentRetries < policy.maxRetries)
   ) {
     const builder = URLBuilder.parse(request.url);
     builder.setPath(locationHeader);
     request.url = builder.toString();
 
-    // POST request with Status code 303 should be converted into a
+    // POST request with Status code 302 and 303 should be converted into a
     // redirected GET request if the redirect url is present in the location header
-    if (status === 303) {
+    // reference: https://tools.ietf.org/html/rfc7231#page-57 && https://fetch.spec.whatwg.org/#http-redirect-fetch
+    if (status === 302 || status === 303) {
       request.method = "GET";
     }
 

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -45,8 +45,7 @@ function handleRedirect(
   if (
     locationHeader &&
     (status === 300 || status === 302 || status === 307 || (status === 303 && request.method === "POST")) &&
-    (currentRetries < policy.maxRetries)
-  ) {
+    (request.redirectLimit && currentRetries < request.redirectLimit)) {
     const builder = URLBuilder.parse(request.url);
     builder.setPath(locationHeader);
     request.url = builder.toString();

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -45,7 +45,11 @@ function handleRedirect(
   if (
     locationHeader &&
     (status === 300 || status === 302 || status === 307 || (status === 303 && request.method === "POST")) &&
-    (request.redirectLimit && currentRetries < request.redirectLimit)) {
+    (
+      (request.redirectLimit !== undefined && currentRetries < request.redirectLimit)
+      ||
+      (request.redirectLimit === undefined && currentRetries < policy.maxRetries)
+    )) {
     const builder = URLBuilder.parse(request.url);
     builder.setPath(locationHeader);
     request.url = builder.toString();

--- a/lib/policies/redirectPolicy.ts
+++ b/lib/policies/redirectPolicy.ts
@@ -95,6 +95,7 @@ function handleRedirect(
 }
 
 function recordRedirect(response: HttpOperationResponse, redirect: string): HttpOperationResponse {
+  // This is called as the recursive calls to handleRedirect() unwind,
   // only record the deepest/last redirect
   if (!response.redirected) {
     response.redirected = true;

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -26,7 +26,7 @@ import {
   getDefaultUserAgentHeaderName,
   getDefaultUserAgentValue,
 } from "./policies/userAgentPolicy";
-import { RedirectPolicy } from "./policies/redirectPolicy";
+import { redirectPolicy } from "./policies/redirectPolicy";
 import {
   RequestPolicy,
   RequestPolicyFactory,
@@ -240,24 +240,12 @@ export class ServiceClient {
     let httpPipeline: RequestPolicy = this._httpClient;
     if (this._requestPolicyFactories && this._requestPolicyFactories.length > 0) {
       for (let i = this._requestPolicyFactories.length - 1; i >= 0; --i) {
-        const nextPolicyPipeline = this._requestPolicyFactories[i].create(
+        httpPipeline = this._requestPolicyFactories[i].create(
           httpPipeline,
           this._requestPolicyOptions
         );
-
-        if (httpRequest.redirectLimit !== undefined && nextPolicyPipeline instanceof RedirectPolicy) {
-          // if redirect behaviour is specified on the request, we don't want the client's default redirectPolicy to apply
-          continue;
-        }
-
-        httpPipeline = nextPolicyPipeline;
       }
     }
-
-    if (httpRequest.redirectLimit !== undefined) {
-      httpPipeline = new RedirectPolicy(httpPipeline, this._requestPolicyOptions, httpRequest.redirectLimit);
-    }
-
     return httpPipeline.sendRequest(httpRequest);
   }
 
@@ -593,6 +581,7 @@ function createDefaultRequestPolicyFactories(
   if (userAgentHeaderName && userAgentHeaderValue) {
     factories.push(userAgentPolicy({ key: userAgentHeaderName, value: userAgentHeaderValue }));
   }
+  factories.push(redirectPolicy());
   factories.push(rpRegistrationPolicy(options.rpRegistrationRetryTimeout));
 
   if (!options.noRetryPolicy) {

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -26,7 +26,7 @@ import {
   getDefaultUserAgentHeaderName,
   getDefaultUserAgentValue,
 } from "./policies/userAgentPolicy";
-import { redirectPolicy } from "./policies/redirectPolicy";
+import { DefaultRedirectOptions, RedirectOptions, redirectPolicy } from "./policies/redirectPolicy";
 import {
   RequestPolicy,
   RequestPolicyFactory,
@@ -135,6 +135,10 @@ export interface ServiceClientOptions {
    * Proxy settings which will be used for every HTTP request (Node.js only).
    */
   proxySettings?: ProxySettings;
+  /**
+   * Options for how redirect responses are handled.
+   */
+  redirectOptions?: RedirectOptions;
   /**
    * HTTP and HTTPS agents which will be used for every HTTP request (Node.js only).
    */
@@ -581,7 +585,15 @@ function createDefaultRequestPolicyFactories(
   if (userAgentHeaderName && userAgentHeaderValue) {
     factories.push(userAgentPolicy({ key: userAgentHeaderName, value: userAgentHeaderValue }));
   }
-  factories.push(redirectPolicy());
+
+  const redirectOptions = {
+    ...DefaultRedirectOptions,
+    ...options.redirectOptions,
+  };
+  if (redirectOptions.handleRedirects) {
+    factories.push(redirectPolicy(redirectOptions.maxRetries));
+  }
+
   factories.push(rpRegistrationPolicy(options.rpRegistrationRetryTimeout));
 
   if (!options.noRetryPolicy) {

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.3.0",
+  msRestVersion: "2.3.1",
 
   /**
    * Specifies HTTP.

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.4.0",
+  msRestVersion: "2.5.0",
 
   /**
    * Specifies HTTP.

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -123,6 +123,11 @@ export interface WebResourceLike {
    * If the connection should be reused.
    */
   keepAlive?: boolean;
+  /**
+   * Limit the number of redirects followed for this request. If set to 0, redirects will not be followed.
+   * If left undefined the default redirect behaviour of the underlying node_fetch will apply.
+   */
+  redirectLimit?: number;
 
   /**
    * Used to abort the request later.
@@ -211,6 +216,7 @@ export class WebResource {
   proxySettings?: ProxySettings;
   keepAlive?: boolean;
   agentSettings?: AgentSettings;
+  redirectLimit?: number;
 
   abortSignal?: AbortSignalLike;
 
@@ -234,7 +240,8 @@ export class WebResource {
     onDownloadProgress?: (progress: TransferProgressEvent) => void,
     proxySettings?: ProxySettings,
     keepAlive?: boolean,
-    agentSettings?: AgentSettings
+    agentSettings?: AgentSettings,
+    redirectLimit?: number
   ) {
     this.streamResponseBody = streamResponseBody;
     this.url = url || "";
@@ -251,6 +258,7 @@ export class WebResource {
     this.proxySettings = proxySettings;
     this.keepAlive = keepAlive;
     this.agentSettings = agentSettings;
+    this.redirectLimit = redirectLimit;
   }
 
   /**
@@ -471,6 +479,7 @@ export class WebResource {
     this.abortSignal = options.abortSignal;
     this.onDownloadProgress = options.onDownloadProgress;
     this.onUploadProgress = options.onUploadProgress;
+    this.redirectLimit = options.redirectLimit;
 
     return this;
   }
@@ -494,7 +503,8 @@ export class WebResource {
       this.onDownloadProgress,
       this.proxySettings,
       this.keepAlive,
-      this.agentSettings
+      this.agentSettings,
+      this.redirectLimit
     );
 
     if (this.formData) {
@@ -603,6 +613,12 @@ export interface RequestPrepareOptions {
    */
   bodyIsStream?: boolean;
   abortSignal?: AbortSignalLike;
+  /**
+   * Limit the number of redirects followed for this request. If set to 0, redirects will not be followed.
+   * If left undefined the default redirect behaviour of the underlying node_fetch will apply.
+   */
+  redirectLimit?: number;
+
   onUploadProgress?: (progress: TransferProgressEvent) => void;
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/policies/redirectPolicyTests.ts
+++ b/test/policies/redirectPolicyTests.ts
@@ -1,0 +1,274 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { RedirectPolicy } from "../../lib/policies/redirectPolicy";
+import { WebResource } from "../../lib/webResource";
+import { HttpOperationResponse } from "../../lib/httpOperationResponse";
+import { HttpHeaders } from "../../lib/httpHeaders";
+import { RequestPolicyOptions } from "../../lib/policies/requestPolicy";
+
+describe("RedirectPolicy", () => {
+  it("should not follow redirect if no location header", async () => {
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "GET");
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, 301);
+  });
+
+  it("should not follow POST 301 redirect", async function () {
+    const expectedStatusCode = 301;
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "POST");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 301 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow HEAD 301 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [301];
+    const request = new WebResource("https://example.com", "HEAD");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow POST 302 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [302];
+    const request = new WebResource("https://example.com", "POST");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 302 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [302];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow HEAD 302 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [302];
+    const request = new WebResource("https://example.com", "HEAD");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow POST 303 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [303];
+    const request = new WebResource("https://example.com", "POST");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        if (!responseCodes.length) {
+          assert.strictEqual(_requestToSend.method, "GET", "Expected second request to be GET");
+        }
+
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should not follow GET 303 redirect", async function () {
+    const expectedStatusCode = 303;
+    const responseCodes = [303];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 307 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [307];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should follow GET 300 redirect", async function () {
+    const expectedStatusCode = 200;
+    const responseCodes = [300];
+    const request = new WebResource("https://example.com", "GET");
+    const headers = [{ location: "https://example.com/new" }];
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders(headers.shift() || {}),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should only try maxretries", async function () {
+    const expectedStatusCode = 300;
+    const maxretries = 1;
+    const responseCodes = [300, 300, 200];
+    const request = new WebResource("https://example.com", "GET");
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        return Promise.resolve({
+          status: responseCodes.shift() || 200,
+          request: _requestToSend,
+          headers: new HttpHeaders({ location: "https://example.com/new" }),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions(), maxretries);
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+  });
+
+  it("should try to redirect 3 times by default", async function () {
+    const expectedStatusCode = 300;
+    let callCount = 0;
+    const request = new WebResource("https://example.com", "GET");
+    const nextPolicy = {
+      sendRequest: (_requestToSend: WebResource): Promise<HttpOperationResponse> => {
+        callCount++;
+        return Promise.resolve({
+          status: 300,
+          request: _requestToSend,
+          headers: new HttpHeaders({ location: "https://example.com/new" }),
+        });
+      },
+    };
+    const policy = new RedirectPolicy(nextPolicy, new RequestPolicyOptions());
+    const result = await policy.sendRequest(request);
+
+    assert.strictEqual(result.status, expectedStatusCode);
+    assert.strictEqual(callCount, 21);
+  });
+});

--- a/test/redirectLimitTests.ts
+++ b/test/redirectLimitTests.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { expect } from "chai";
+import sinon from "sinon";
+
+import { DefaultHttpClient } from "../lib/defaultHttpClient";
+import { WebResource } from "../lib/webResource";
+import { getHttpMock, HttpMockFacade } from "./mockHttp";
+import { CommonResponse } from "../lib/fetchHttpClient";
+import { ServiceClient } from "../lib/serviceClient";
+import { isNode } from "../lib/msRest";
+import { TestFunction } from "mocha";
+
+const nodeIt = (isNode ? it : it.skip) as TestFunction;
+
+describe("redirectLimit", function () {
+
+  let httpMock: HttpMockFacade;
+  let capturedRedirectInit: string | undefined;
+  beforeEach(() => {
+    httpMock = getHttpMock();
+    httpMock.setup();
+    capturedRedirectInit = undefined;
+  });
+  afterEach(() => httpMock.teardown());
+
+  function getMockedHttpClient(): DefaultHttpClient {
+    const httpClient = new DefaultHttpClient();
+    const fetchMock = httpMock.getFetch();
+    if (fetchMock) {
+      sinon.stub(httpClient, "fetch").callsFake(async (input, init) => {
+        capturedRedirectInit = init?.redirect;
+        const response = await fetchMock(input, init);
+        return (response as unknown) as CommonResponse;
+      });
+    }
+    return httpClient;
+  }
+
+  async function executeRequestWithRedirectLimit(redirectLimit?: number) {
+    const resourceUrl = "/resource";
+
+    httpMock.get(resourceUrl, async () => {
+      return { status: 200 };
+    });
+
+    const httpClient = getMockedHttpClient();
+    const request = new WebResource().prepare({ url: resourceUrl, method: "GET", redirectLimit});
+
+    // Act
+    await httpClient.sendRequest(request);
+  }
+
+  nodeIt("should initiate fetch without overriding redirect when redirectLimit is undefined", async function () {
+    await executeRequestWithRedirectLimit(undefined);
+
+    expect(capturedRedirectInit).to.be.undefined;
+  });
+
+  nodeIt("should initiate fetch with manual redirect when redirectLimit is 0", async function () {
+    await executeRequestWithRedirectLimit(0);
+
+    expect(capturedRedirectInit).to.equal("manual");
+  });
+
+  nodeIt("should initiate fetch with manual redirect when redirectLimit is greater than 0", async function () {
+    await executeRequestWithRedirectLimit(3);
+
+    expect(capturedRedirectInit).to.equal("manual");
+  });
+
+  const resourceUrl = "/resource";
+  const redirectedUrl_1 = "/redirected_1";
+  const redirectedUrl_2 = "/redirected_2";
+
+  function configureMockRedirectResponses() {
+    httpMock.get(resourceUrl, async () => {
+      return { status: 300, headers : {"location": redirectedUrl_1} };
+    });
+    httpMock.get(redirectedUrl_1, async () => {
+      return { status: 300, headers : {"location": redirectedUrl_2} };
+    });
+    httpMock.get(redirectedUrl_2, async () => {
+      return { status: 200 };
+    });
+  }
+
+  nodeIt("of 20 should follow redirects and return last visited url in response.url", async function () {
+    configureMockRedirectResponses();
+
+    const client = new ServiceClient(undefined, {
+      httpClient: getMockedHttpClient(),
+      requestPolicyFactories: [],
+    });
+
+    // Act
+    const response = await client.sendRequest({ url: resourceUrl, method: "GET", redirectLimit: 20});
+
+    expect(response.status).to.equal(200);
+    expect(response.redirected).to.be.true;
+    expect(response.url).to.equal(redirectedUrl_2);
+  });
+
+  nodeIt("of 0 should not follow redirects and should return last visited url in response.url", async function () {
+    configureMockRedirectResponses();
+
+    const client = new ServiceClient(undefined, {
+      httpClient: getMockedHttpClient(),
+      requestPolicyFactories: [],
+    });
+
+    // Act
+    const response = await client.sendRequest({ url: resourceUrl, method: "GET", redirectLimit: 0});
+
+    expect(response.status).to.equal(300);
+    expect(response.headers.get("location")).to.equal(redirectedUrl_1);
+    expect(response.redirected).to.be.false;
+    expect(response.url).to.equal(resourceUrl);
+  });
+
+  nodeIt("of 1 should follow 1 redirect and return last visited url in response.url", async function () {
+    configureMockRedirectResponses();
+
+    const client = new ServiceClient(undefined, {
+      httpClient: getMockedHttpClient(),
+      requestPolicyFactories: [],
+    });
+
+    // Act
+    const response = await client.sendRequest({ url: resourceUrl, method: "GET", redirectLimit: 1});
+
+    expect(response.status).to.equal(300);
+    expect(response.headers.get("location")).to.equal(redirectedUrl_2);
+    expect(response.redirected).to.be.true;
+    expect(response.url).to.equal(redirectedUrl_1);
+  });
+});

--- a/test/redirectLimitTests.ts
+++ b/test/redirectLimitTests.ts
@@ -90,8 +90,7 @@ describe("redirectLimit", function () {
     configureMockRedirectResponses();
 
     const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient(),
-      requestPolicyFactories: [],
+      httpClient: getMockedHttpClient()
     });
 
     // Act
@@ -106,8 +105,7 @@ describe("redirectLimit", function () {
     configureMockRedirectResponses();
 
     const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient(),
-      requestPolicyFactories: [],
+      httpClient: getMockedHttpClient()
     });
 
     // Act
@@ -123,8 +121,7 @@ describe("redirectLimit", function () {
     configureMockRedirectResponses();
 
     const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient(),
-      requestPolicyFactories: [],
+      httpClient: getMockedHttpClient()
     });
 
     // Act

--- a/test/redirectLimitTests.ts
+++ b/test/redirectLimitTests.ts
@@ -5,7 +5,6 @@ import { expect } from "chai";
 import sinon from "sinon";
 
 import { DefaultHttpClient } from "../lib/defaultHttpClient";
-import { WebResource } from "../lib/webResource";
 import { getHttpMock, HttpMockFacade } from "./mockHttp";
 import { CommonResponse } from "../lib/fetchHttpClient";
 import { ServiceClient } from "../lib/serviceClient";
@@ -16,13 +15,10 @@ import { redirectPolicy } from "../lib/policies/redirectPolicy";
 const nodeIt = (isNode ? it : it.skip) as TestFunction;
 
 describe("redirectLimit", function () {
-
   let httpMock: HttpMockFacade;
-  let capturedRedirectInit: string | undefined;
   beforeEach(() => {
     httpMock = getHttpMock();
     httpMock.setup();
-    capturedRedirectInit = undefined;
   });
   afterEach(() => httpMock.teardown());
 
@@ -31,7 +27,6 @@ describe("redirectLimit", function () {
     const fetchMock = httpMock.getFetch();
     if (fetchMock) {
       sinon.stub(httpClient, "fetch").callsFake(async (input, init) => {
-        capturedRedirectInit = init?.redirect;
         const response = await fetchMock(input, init);
         return (response as unknown) as CommonResponse;
       });
@@ -39,130 +34,125 @@ describe("redirectLimit", function () {
     return httpClient;
   }
 
-  async function executeRequestWithRedirectLimit(redirectLimit?: number) {
-    const resourceUrl = "/resource";
-
-    httpMock.get(resourceUrl, async () => {
-      return { status: 200 };
-    });
-
-    const httpClient = getMockedHttpClient();
-    const request = new WebResource().prepare({ url: resourceUrl, method: "GET", redirectLimit});
-
-    // Act
-    await httpClient.sendRequest(request);
-  }
-
-  nodeIt("should initiate fetch without overriding redirect when redirectLimit is undefined", async function () {
-    await executeRequestWithRedirectLimit(undefined);
-
-    expect(capturedRedirectInit).to.be.undefined;
-  });
-
-  nodeIt("should initiate fetch with manual redirect when redirectLimit is 0", async function () {
-    await executeRequestWithRedirectLimit(0);
-
-    expect(capturedRedirectInit).to.equal("manual");
-  });
-
-  nodeIt("should initiate fetch with manual redirect when redirectLimit is greater than 0", async function () {
-    await executeRequestWithRedirectLimit(3);
-
-    expect(capturedRedirectInit).to.equal("manual");
-  });
-
   const resourceUrl = "/resource";
   const redirectedUrl_1 = "/redirected_1";
   const redirectedUrl_2 = "/redirected_2";
 
   function configureMockRedirectResponses() {
     httpMock.get(resourceUrl, async () => {
-      return { status: 300, headers : {"location": redirectedUrl_1} };
+      return { status: 300, headers: { location: redirectedUrl_1 } };
     });
     httpMock.get(redirectedUrl_1, async () => {
-      return { status: 300, headers : {"location": redirectedUrl_2} };
+      return { status: 300, headers: { location: redirectedUrl_2 } };
     });
     httpMock.get(redirectedUrl_2, async () => {
       return { status: 200 };
     });
   }
 
-  nodeIt("of 20 should follow redirects and return last visited url in response.url", async function () {
-    configureMockRedirectResponses();
+  nodeIt(
+    "of 20 should follow redirects and return last visited url in response.url",
+    async function () {
+      configureMockRedirectResponses();
 
-    const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient()
-    });
+      const client = new ServiceClient(undefined, {
+        httpClient: getMockedHttpClient(),
+      });
 
-    // Act
-    const response = await client.sendRequest({ url: resourceUrl, method: "GET", redirectLimit: 20});
+      // Act
+      const response = await client.sendRequest({
+        url: resourceUrl,
+        method: "GET",
+        redirectLimit: 20,
+      });
 
-    expect(response.status).to.equal(200);
-    expect(response.redirected).to.be.true;
-    expect(response.url).to.equal(redirectedUrl_2);
-  });
+      expect(response.status).to.equal(200);
+      expect(response.redirected).to.be.true;
+      expect(response.url).to.equal(redirectedUrl_2);
+    }
+  );
 
-  nodeIt("of 0 should not follow redirects and should return last visited url in response.url", async function () {
-    configureMockRedirectResponses();
+  nodeIt(
+    "of 0 should not follow redirects and should return last visited url in response.url",
+    async function () {
+      configureMockRedirectResponses();
 
-    const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient()
-    });
+      const client = new ServiceClient(undefined, {
+        httpClient: getMockedHttpClient(),
+      });
 
-    // Act
-    const response = await client.sendRequest({ url: resourceUrl, method: "GET", redirectLimit: 0});
+      // Act
+      const response = await client.sendRequest({
+        url: resourceUrl,
+        method: "GET",
+        redirectLimit: 0,
+      });
 
-    expect(response.status).to.equal(300);
-    expect(response.headers.get("location")).to.equal(redirectedUrl_1);
-    expect(response.redirected).to.be.false;
-    expect(response.url).to.equal(resourceUrl);
-  });
+      expect(response.status).to.equal(300);
+      expect(response.headers.get("location")).to.equal(redirectedUrl_1);
+      expect(response.redirected).to.be.false;
+      expect(response.url).to.equal(resourceUrl);
+    }
+  );
 
-  nodeIt("of 1 should follow 1 redirect and return last visited url in response.url", async function () {
-    configureMockRedirectResponses();
+  nodeIt(
+    "of 1 should follow 1 redirect and return last visited url in response.url",
+    async function () {
+      configureMockRedirectResponses();
 
-    const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient()
-    });
+      const client = new ServiceClient(undefined, {
+        httpClient: getMockedHttpClient(),
+      });
 
-    // Act
-    const response = await client.sendRequest({ url: resourceUrl, method: "GET", redirectLimit: 1});
+      // Act
+      const response = await client.sendRequest({
+        url: resourceUrl,
+        method: "GET",
+        redirectLimit: 1,
+      });
 
-    expect(response.status).to.equal(300);
-    expect(response.headers.get("location")).to.equal(redirectedUrl_2);
-    expect(response.redirected).to.be.true;
-    expect(response.url).to.equal(redirectedUrl_1);
-  });
+      expect(response.status).to.equal(300);
+      expect(response.headers.get("location")).to.equal(redirectedUrl_2);
+      expect(response.redirected).to.be.true;
+      expect(response.url).to.equal(redirectedUrl_1);
+    }
+  );
 
-  nodeIt("of undefined should follow redirects and return last visited url in response.url", async function () {
-    configureMockRedirectResponses();
+  nodeIt(
+    "of undefined should follow redirects and return last visited url in response.url",
+    async function () {
+      configureMockRedirectResponses();
 
-    const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient()
-    });
+      const client = new ServiceClient(undefined, {
+        httpClient: getMockedHttpClient(),
+      });
 
-    // Act
-    const response = await client.sendRequest({ url: resourceUrl, method: "GET" });
+      // Act
+      const response = await client.sendRequest({ url: resourceUrl, method: "GET" });
 
-    expect(response.status).to.equal(200);
-    expect(response.redirected).to.be.true;
-    expect(response.url).to.equal(redirectedUrl_2);
-  });
+      expect(response.status).to.equal(200);
+      expect(response.redirected).to.be.true;
+      expect(response.url).to.equal(redirectedUrl_2);
+    }
+  );
 
-  nodeIt("of undefinded with policy limit of 1 should follow 1 redirect and return last visited url in response.url", async function () {
-    configureMockRedirectResponses();
+  nodeIt(
+    "of undefinded with policy limit of 1 should follow 1 redirect and return last visited url in response.url",
+    async function () {
+      configureMockRedirectResponses();
 
-    const client = new ServiceClient(undefined, {
-      httpClient: getMockedHttpClient(),
-      requestPolicyFactories: [redirectPolicy(1)],
-    });
+      const client = new ServiceClient(undefined, {
+        httpClient: getMockedHttpClient(),
+        requestPolicyFactories: [redirectPolicy(1)],
+      });
 
-    // Act
-    const response = await client.sendRequest({ url: resourceUrl, method: "GET" });
+      // Act
+      const response = await client.sendRequest({ url: resourceUrl, method: "GET" });
 
-    expect(response.status).to.equal(300);
-    expect(response.headers.get("location")).to.equal(redirectedUrl_2);
-    expect(response.redirected).to.be.true;
-    expect(response.url).to.equal(redirectedUrl_1);
-  });
+      expect(response.status).to.equal(300);
+      expect(response.headers.get("location")).to.equal(redirectedUrl_2);
+      expect(response.redirected).to.be.true;
+      expect(response.url).to.equal(redirectedUrl_1);
+    }
+  );
 });


### PR DESCRIPTION
In our usage we want to be able to specify the redirect behaviour for an individual request. I have added the property `redirectLimit` to `RequestPrepareOptions` and `WebResource`. 

It turns out the existing `redirectPolicy` was never executed as the call to node-fetch does not override the default value of redirect='follow'. As it was, node-fetch processed all redirects before the redirectPolicy was executed. I have modified this so that if a redirectLimit is defined, the call to node-fetch will use redirect='manual'

I've also added `url?:string` and `redirected?:boolean` to the response to mimic the behaviour of node fetch. Returning these values seems logical, and in our usage we require them in the response.

I have tried to write some tests that cover the main behavioural changes, but there are no existing tests around the  redirectPolicy. The redirectPolicy code seems to behave differently to other implementations. It would be a good future task to write a set of tests that expect the standard redirect behaviour, maybe based off the node-fetch behavior and documentation, and then to modify the redirectPolicy code to pass these tests.

Happy for all feedback.
Regards
Paul