### PR TITLE
Update WebResource.prepare to also copy streamResponseBody

### DIFF
--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -471,6 +471,7 @@ export class WebResource {
     this.abortSignal = options.abortSignal;
     this.onDownloadProgress = options.onDownloadProgress;
     this.onUploadProgress = options.onUploadProgress;
+    this.streamResponseBody = options.streamResponseBody;
 
     return this;
   }

--- a/lib/webResource.ts
+++ b/lib/webResource.ts
@@ -606,6 +606,7 @@ export interface RequestPrepareOptions {
   abortSignal?: AbortSignalLike;
   onUploadProgress?: (progress: TransferProgressEvent) => void;
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+  streamResponseBody?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #393. If a simple options object is passed to `sendRequest`, [this code](https://github.com/Azure/ms-rest-js/blob/4208098ab146ad6d37611306c01aac3c93db0941/lib/serviceClient.ts#L227-L238) tries to normalize it into a common `WebResource` object via `WebResource.prepare`. This method does not currently copy in `streamResponseBody` from the options, but it should, so this PR fixes that.