### PR TITLE
Expose AzureIdentityCredentialAdapter in the public API

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,60 +1,78 @@
 # Changelog
 
+## 2.4.0 - 2021-04-19
+
+- Expose `AzureIdentityCredentialAdapter` in the public API to enable users of this package make use of credentials from `@azure/identity`.
+
 ## 2.3.0 - 2021-03-29
+
 - Moving @types dependencies into devdependencies
 - Add NO_PROXY and ALL_PROXY support.
 - Add username/password support in proxy url string.
 - Update `WebResource.prepare()` to also copy `streamResponseBody`.
 
 ## 2.2.3 - 2021-02-10
+
 - Dependent projects of @azure/ms-rest-js no longer need to have a dev dependency on @types/tunnel.
 
 ## 2.2.2 - 2021-02-09
+
 - Port fix for nextLink issue from core-http (PR [#426](https://github.com/Azure/ms-rest-js/pull/426))
 - Fix abort signal event handler memory leak (PR [#425](https://github.com/Azure/ms-rest-js/pull/425))
 - Rework the use of `lib: ["dom"]` so consumers of this package don't need it in their tsconfig. Fixes (Issue [#367](https://github.com/Azure/ms-rest-js/issues/367))
 
 ## 2.2.1 - 2021-02-05
+
 - Fix issue of `SystemErrorRetryPolicy` didn't retry on errors (Issue [#412](https://github.com/Azure/ms-rest-js/issues/412))
 - `ThrottlingRetryPolicy` now keep retrying on 429 responses up to a limit. Fixes (Issue [#394](https://github.com/Azure/ms-rest-js/issues/394))
 - The global `fetch()` is no longer overridden by node-fetch. Fixes (Issue [#383](https://github.com/Azure/ms-rest-js/issues/383))
 
 ## 2.2.0 - 2021-01-26
+
 - Add support for @azure/core-auth's TokenCredential (PR [#410](https://github.com/Azure/ms-rest-js/pull/410))
 - Allow = character in parameter value (PR [#408](https://github.com/Azure/ms-rest-js/pull/408))
 
 ## 2.1.0 - 2020-10-08
+
 - Add support for custom http/https agent (PR [#403](https://github.com/Azure/ms-rest-js/pull/403))
 - Fix WebResource clone to include extra settings (Issue [#405](https://github.com/Azure/ms-rest-js/issue/403))
 
 ## 2.0.8 - 2020-07-23
+
 - [BugFix] - Fixed loading of proxyPolicy.browser.js in the HTML files.(PR [#397](https://github.com/Azure/ms-rest-js/pull/397))
 
 ## 2.0.7 - 2020-04-30
+
 - Fixes encoding query parameters in an array before joining them.(PR [#382](https://github.com/Azure/ms-rest-js/pull/382))
 - Replace public usage of `RequestPolicyOptions` to an interface `RequestPolicyOptionsLike` to avoid compatibility issues with private members.
 - Fix issue with null/undefined values in array and tabs/space delimiter arrays during sendOperationRequest. [PR #390](https://github.com/Azure/ms-rest-js/pull/390)
 - Fix in flattenResponse when expecting an array, checking for parsedBody to be an array before proceeding with flattening. (PR [#385](https://github.com/Azure/ms-rest-js/pull/385))
- 
+
 ## 2.0.6 - 2020-04-15
-- A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`.  This change was added to improve compatibility between `@azure/core-http` and `@azure/ms-rest-nodeauth`.
+
+- A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`. This change was added to improve compatibility between `@azure/core-http` and `@azure/ms-rest-nodeauth`.
 
 ## 2.0.5 - 2020-01-07
+
 - Fix node-fetch bundling when using Webpack (PR [#376](https://github.com/Azure/ms-rest-js/pull/376)).
 
 ## 2.0.4 - 2019-07-30
+
 - Ensure that a primitive type (string, number, boolean, null, undefined) response body with or without a `bodyMapper` is not flattened.
 
 ## 2.0.3 - 2019-07-11
+
 - Added support to not send default values while sending the request.
 - Added support to populate entities with it's default value if it is present in the mapper while deserializing the response.
 - During deserialization, if the service does not provide the discriminator property then we set it. While setting the discriminator property, we compare model property name and the `clientName` of the `polymorphicDiscriminator` instead of the `serializedName` of the `polymorphicDiscriminator`.
 - Added tests for serializing and deserializing additional properties.
 
 ## 2.0.2 - 2019-07-08
+
 - Updated `cookieJar.setCookie()` with `{ ignoreError: true }` for `NodeFetchHttpClient`. This should silently ignore things like parse errors and invalid domains. This should resolve issues where customers using the `@azure/arm-appservice` package get an error due to mismatch in the domain [Azure/azure-sdk-for-js#1008](https://github.com/Azure/azure-sdk-for-js/issues/1008). This behavior makes it consistent with the old package [azure-arm-website](https://www.npmjs.com/package/azure-arm-website) which depends on the runtime [ms-rest](https://www.npmjs.com/package/ms-rest) that depends on the [request](https://www.npmjs.com/package/request) library which uses the [tough-cookie](https://www.npmjs.com/package/tough-cookie) package in `{ looseMode: true }` by [default](https://github.com/request/request/blob/536f0e76b249e4545c3ba2ac75e643146ebf3824/lib/cookies.js#L21) with `{ ignoreError: true }` as can be seen [here](https://github.com/request/request/blob/df346d8531ac4b8c360df301f228d5767d0e374e/request.js#L969).
 
 ## 2.0.1 - 2019-06-26
+
 - Updated tests to include Pattern constraint
 
 ## 2.0.0 - 2019-06-21
@@ -81,9 +99,9 @@
 
 ## 1.8.10 - 2019-06-05
 
-- `axios` changed the way it treats properties of the request config in `0.19.0`. Previously we were setting `trasnformResponse` to `undefined`. This would indicate `axios` to not transform (`JSON.parse()`) the response body. In `0.19.0`, they are setting the default response transformer if transformResponse is set to `undefined`. This breaks our pasrsing logic where we are doing `JSON.parse()` on `operationResponse.bodyAsText`. Moreover, we are exposing the `bodyAsText` property in the generated clients. 
-Not populating this property or setting the value of this property to a parsed JSON would be a breaking change for our users.
-Hence we are setting the `transformResponse` property in the request config to an indentity function that returns the response body as-is.
+- `axios` changed the way it treats properties of the request config in `0.19.0`. Previously we were setting `trasnformResponse` to `undefined`. This would indicate `axios` to not transform (`JSON.parse()`) the response body. In `0.19.0`, they are setting the default response transformer if transformResponse is set to `undefined`. This breaks our pasrsing logic where we are doing `JSON.parse()` on `operationResponse.bodyAsText`. Moreover, we are exposing the `bodyAsText` property in the generated clients.
+  Not populating this property or setting the value of this property to a parsed JSON would be a breaking change for our users.
+  Hence we are setting the `transformResponse` property in the request config to an indentity function that returns the response body as-is.
 
 ## 1.8.9 - 2019-06-04
 
@@ -92,7 +110,7 @@ Hence we are setting the `transformResponse` property in the request config to a
 ## 1.8.8 - 2019-06-03
 
 - Fixed vulnerabilities by bumping `axios` to `^0.19.0`.
-- New version of axios fixed some issues hence removed one of the workarounds of uppercasing method names while following redirects [axios PR](https://github.com/axios/axios/pull/1758). 
+- New version of axios fixed some issues hence removed one of the workarounds of uppercasing method names while following redirects [axios PR](https://github.com/axios/axios/pull/1758).
 
 ## 1.8.7 - 2019-05-16
 

--- a/lib/msRest.ts
+++ b/lib/msRest.ts
@@ -94,3 +94,4 @@ export { ServiceClientCredentials } from "./credentials/serviceClientCredentials
 export { TopicCredentials } from "./credentials/topicCredentials";
 export { DomainCredentials } from "./credentials/domainCredentials";
 export { Authenticator } from "./credentials/credentials";
+export { AzureIdentityCredentialAdapter } from "./credentials/azureIdentityTokenCredentialAdapter";

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.3.0",
+  msRestVersion: "2.4.0",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
The `AzureIdentityCredentialAdapter` allows users of this package to make use of credentials from `@azure/identity`.
When it was added, the plan was to then update the auto generated packages that depend on this package to have a constructor overload that would take the `TokenCredential` interface. As it would take a while to update over 150 packages to have this change, it is beneficial to expose this adapter for folks who may want to make use of it sooner.

Case in point: #445

