### PR TITLE
Use self instead of window when referring to the global object

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.1 - (unreleased)
+
+- Use `self` instead of `window` in order to support web workers.
+
 ## 2.4.0 - 2021-04-19
 
 - Expose `AzureIdentityCredentialAdapter` in the public API to enable users of this package make use of credentials from `@azure/identity`.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4.1 - (unreleased)
+## 2.4.1 - (2021-05-05)
 
 - Use `self` instead of `window` in order to support web workers.
 

--- a/lib/policies/msRestUserAgentPolicy.browser.ts
+++ b/lib/policies/msRestUserAgentPolicy.browser.ts
@@ -18,7 +18,7 @@ export function getDefaultUserAgentKey(): string {
 }
 
 export function getPlatformSpecificData(): TelemetryInfo[] {
-  const navigator = window.navigator as NavigatorEx;
+  const navigator = self.navigator as NavigatorEx;
   const osInfo = {
     key: "OS",
     value: (navigator.oscpu || navigator.platform).replace(" ", ""),

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.4.0",
+  msRestVersion: "2.4.1",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
## What

- Use self instead of window when referring to the global object

## Why

- This came up recently in a few cases: https://github.com/Azure/azure-sdk-for-js/issues/11067 and in this discussion: https://github.com/Azure/azure-sdk-for-js/pull/13232#discussion_r557793538
- window is not always the global object, but self's reference changes depending on the context and will point to the right global object

We made this change in azure-sdk-for-js but we should make it here as well.