### PR TITLE
Allow password-less proxySettings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 2.5.2 - (2021-06-15)
+- Fixed an issue where `proxySettings` does not work when there is username but no password (PR [453](https://github.com/Azure/ms-rest-js/pull/453))
+
 ## 2.5.1 - (2021-06-07)
 - [BugFix] Array flattening in deserializer loses previously de-serialized attributes (PR [#451](https://github.com/Azure/ms-rest-js/pull/451))
 

--- a/lib/proxyAgent.ts
+++ b/lib/proxyAgent.ts
@@ -25,6 +25,8 @@ export function createProxyAgent(
 
   if (proxySettings.username && proxySettings.password) {
     tunnelOptions.proxy!.proxyAuth = `${proxySettings.username}:${proxySettings.password}`;
+  } else if (proxySettings.username) {
+    tunnelOptions.proxy!.proxyAuth = `${proxySettings.username}`;
   }
 
   const requestScheme = URLBuilder.parse(requestUrl).getScheme() || "";

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.5.1",
+  msRestVersion: "2.5.2",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/proxyAgent.node.ts
+++ b/test/proxyAgent.node.ts
@@ -8,6 +8,7 @@ import https from "https";
 
 import { HttpHeaders } from "../lib/msRest";
 import { createProxyAgent, createTunnel } from "../lib/proxyAgent";
+import { ProxySettings } from "../lib/serviceClient";
 
 describe("proxyAgent", () => {
   describe("createProxyAgent", () => {
@@ -60,6 +61,37 @@ describe("proxyAgent", () => {
 
       const agent = proxyAgent.agent as HttpsAgent;
       agent.proxyOptions.headers!.should.contain({ "user-agent": "Node.js" });
+      done();
+    });
+
+    it("should set agent proxyAuth correctly", function (done) {
+      const proxySettings: ProxySettings = {
+        host: "http://proxy.microsoft.com",
+        port: 8080,
+        username: "username",
+        password: "pass123",
+      };
+
+      const proxyAgent = createProxyAgent("http://example.com", proxySettings);
+
+      const agent = proxyAgent.agent as HttpsAgent;
+      should().exist(agent.options.proxy.proxyAuth);
+      agent.options.proxy.proxyAuth!.should.equal("username:pass123");
+      done();
+    });
+
+    it("should set agent proxyAuth correctly when password is not specified", function (done) {
+      const proxySettings: ProxySettings = {
+        host: "http://proxy.microsoft.com",
+        port: 8080,
+        username: "username",
+      };
+
+      const proxyAgent = createProxyAgent("http://example.com", proxySettings);
+
+      const agent = proxyAgent.agent as HttpsAgent;
+      should().exist(agent.options.proxy.proxyAuth);
+      agent.options.proxy.proxyAuth!.should.equal("username");
       done();
     });
   });


### PR DESCRIPTION
It turns out that in some enterprise customer the proxy auth settings include a
username, but not a password: microsoft/AzureStorageExplorer#4430

This change allows password-less auth settings to be passed to the underlying agent.

It's unclear whether it's a real scenario when a proxy auth has a password, but
not username so this PR doesn't consider this scenario.