### PR TITLE
Upgrade uuid dependency to v8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.3 - (2021-07-12)
+- Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))
+
 ## 2.5.2 - (2021-06-15)
 - Fixed an issue where `proxySettings` does not work when there is username but no password (PR [453](https://github.com/Azure/ms-rest-js/pull/453))
 

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.5.2",
+  msRestVersion: "2.5.3",
 
   /**
    * Specifies HTTP.

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { v4 as uuidv4 } from 'uuid';
+import { v4 as uuidv4 } from "uuid";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { RestError } from "../restError";
 import { WebResourceLike } from "../webResource";

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import uuidv4 from "uuid/v4";
+import { v4 as uuidv4 } from 'uuid';
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { RestError } from "../restError";
 import { WebResourceLike } from "../webResource";

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "tough-cookie": "^3.0.1",
     "tslib": "^1.10.0",
     "tunnel": "0.0.6",
-    "uuid": "^3.3.2",
+    "uuid": "^8.3.2",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -30,7 +30,7 @@ const nodeConfig = {
     "tough-cookie",
     "tslib",
     "tunnel",
-    "uuid/v4",
+    "uuid",
     "xml2js",
   ],
   output: {


### PR DESCRIPTION
From https://github.com/Azure/ms-rest-js/issues/455:
> Currently, installing @azure/ms-rest-js@latest, produces the following message:

> deprecated uuid@3.4.0: Please upgrade to version 7 or higher. Older versions may use Math.random() in certain circumstances, which is known to be problematic. See https://v8.dev/blog/math-random for details.

So this PR upgrades dep on uuid to latest version. Fixes https://github.com/Azure/ms-rest-js/issues/455