### PR TITLE
Adds property baseUri on the ServiceClientOptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.0 - (2021-07-29)
+## 2.6.0 - (2021-08-02)
 
 - Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`. This allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.5.4 - (2021-07-29)
+- When a `TokenCredential` is sent to `ServiceClient`, it now automatically sets the scope of future token requests based on the `baseUri` property.
+
 ## 2.5.3 - (2021-07-12)
 - Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.5.4 - (2021-07-29)
+## 2.6.0 - (2021-07-29)
 
 - Added a new property `baseUri` on the `ServiceClientOptions`, so that when a `TokenCredential` is sent to `ServiceClient`, it now automatically sets the scope of future token requests based on the `options.baseUri` property.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## 2.6.0 - (2021-08-16)
 
 - Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`.
-  - For `baseUri` that happen to be known Azure resource management endpoints, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
+  - For `baseUri` that happen to be known Azure resource manager endpoints, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
 
 ## 2.5.3 - (2021-07-12)
 - Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,8 @@
 
 ## 2.6.0 - (2021-08-02)
 
-- Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`. This allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
+- Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`.
+  - For `baseUri` that happen to be known Azure management clouds, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
 
 ## 2.5.3 - (2021-07-12)
 - Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 2.5.4 - (2021-07-29)
-- When a `TokenCredential` is sent to `ServiceClient`, it now automatically sets the scope of future token requests based on the `baseUri` property.
+
+- Added a new property `baseUri` on the `ServiceClientOptions`, so that when a `TokenCredential` is sent to `ServiceClient`, it now automatically sets the scope of future token requests based on the `options.baseUri` property.
 
 ## 2.5.3 - (2021-07-12)
 - Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ## 2.6.0 - (2021-08-16)
 
 - Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`.
-  - For `baseUri` that happen to be known Azure management clouds, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
+  - For `baseUri` that happen to be known Azure resource management endpoints, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
 
 ## 2.5.3 - (2021-07-12)
 - Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.0 - (2021-08-02)
+## 2.6.0 - (2021-08-16)
 
 - Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`.
   - For `baseUri` that happen to be known Azure management clouds, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 2.6.0 - (2021-07-29)
 
-- Added a new property `baseUri` on the `ServiceClientOptions`, so that when a `TokenCredential` is sent to `ServiceClient`, it now automatically sets the scope of future token requests based on the `options.baseUri` property.
+- Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`. This allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945
 
 ## 2.5.3 - (2021-07-12)
 - Updated the dependency on the uuid package to v8 (PR [456](https://github.com/Azure/ms-rest-js/pull/456))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.6.0 - (2021-08-16)
+## 2.6.0 - (2021-08-18)
 
 - Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`.
   - For `baseUri` that happen to be known Azure resource manager endpoints, this allows the instantiating of the `AzureIdentityCredentialAdapter` class with the right scope when a user constructs a `ServiceClient` with a `TokenCredential`. Resolves https://github.com/Azure/azure-sdk-for-js/issues/15945

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -11,6 +11,16 @@ import { TokenResponse } from "./tokenResponse";
 const DEFAULT_AUTHORIZATION_SCHEME = "Bearer";
 
 /**
+ * Resource manager endpoints to match in order to specify a valid scope to the AzureIdentityCredentialAdapter.
+ */
+export const azureResourceManagerEndpoints = [
+  "https://management.windows.net",
+  "https://management.chinacloudapi.cn",
+  "https://management.usgovcloudapi.net",
+  "https://management.cloudapi.de",
+];
+
+/**
  * This class provides a simple extension to use {@link TokenCredential} from `@azure/identity` library to
  * use with legacy Azure SDKs that accept {@link ServiceClientCredentials} family of credentials for authentication.
  */

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -25,8 +25,15 @@ export class AzureIdentityCredentialAdapter implements ServiceClientCredentials 
     this.scopes = scopes;
   }
 
+  private _scopesSetter: () => string | undefined = () => undefined;
+  public scopesSetter(setter: () => string | undefined): void {
+    this._scopesSetter = setter;
+  }
+
   public async getToken(): Promise<TokenResponse> {
-    const accessToken = await this.azureTokenCredential.getToken(this.scopes);
+    const accessToken = await this.azureTokenCredential.getToken(
+      this._scopesSetter() ?? this.scopes
+    );
     if (accessToken !== null) {
       const result: TokenResponse = {
         accessToken: accessToken.token,

--- a/lib/credentials/azureIdentityTokenCredentialAdapter.ts
+++ b/lib/credentials/azureIdentityTokenCredentialAdapter.ts
@@ -25,15 +25,8 @@ export class AzureIdentityCredentialAdapter implements ServiceClientCredentials 
     this.scopes = scopes;
   }
 
-  private _scopesSetter: () => string | undefined = () => undefined;
-  public scopesSetter(setter: () => string | undefined): void {
-    this._scopesSetter = setter;
-  }
-
   public async getToken(): Promise<TokenResponse> {
-    const accessToken = await this.azureTokenCredential.getToken(
-      this._scopesSetter() ?? this.scopes
-    );
+    const accessToken = await this.azureTokenCredential.getToken(this.scopes);
     if (accessToken !== null) {
       const result: TokenResponse = {
         accessToken: accessToken.token,

--- a/lib/serializer.ts
+++ b/lib/serializer.ts
@@ -735,7 +735,11 @@ function deserializeCompositeType(
       // paging
       if (Array.isArray(responseBody[key]) && modelProps[key].serializedName === "") {
         propertyInstance = responseBody[key];
-        const arrayInstance = serializer.deserialize(propertyMapper, propertyInstance, propertyObjectName);
+        const arrayInstance = serializer.deserialize(
+          propertyMapper,
+          propertyInstance,
+          propertyObjectName
+        );
         // Copy over any properties that have already been added into the instance, where they do
         // not exist on the newly de-serialized array
         for (const [key, value] of Object.entries(instance)) {

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -207,10 +207,10 @@ export class ServiceClient {
     if (isTokenCredential(credentials)) {
       let scope: string | undefined = undefined;
       const azureManagementClouds = [
-        "https://management.core.windows.net",
-        "https://management.core.chinacloudapi.cn",
-        "https://management.core.usgovcloudapi.net",
-        "https://management.core.cloudapi.de",
+        "https://management.windows.net",
+        "https://management.chinacloudapi.cn",
+        "https://management.usgovcloudapi.net",
+        "https://management.cloudapi.de",
       ];
       if (
         options?.baseUri &&

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -190,6 +190,10 @@ export class ServiceClient {
       options = {};
     }
 
+    if (options.baseUri) {
+      this.baseUri = options.baseUri;
+    }
+
     let serviceClientCredentials: ServiceClientCredentials | undefined;
     if (isTokenCredential(credentials)) {
       serviceClientCredentials = new AzureIdentityCredentialAdapter(

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -144,11 +144,11 @@ export interface ServiceClientOptions {
    */
   agentSettings?: AgentSettings;
   /**
-   * If specified, and if the value matches a resource management endpoint URI:
+   * If specified, and if the value matches a known resource management endpoint:
    * - This `baseUri` becomes the base URI that requests will be made against for this ServiceClient.
    * - If a `TokenCredential` was passed through the constructor, this `baseUri` defines the `getToken` scope to be `${options.baseUri}/.default`.
    *
-   * If it is not specified, or if it doesn't match a resource management endpoint URI:
+   * If it is not specified, or if it doesn't match a known resource management endpoint:
    * - All OperationSpecs must contain a baseUrl property.
    * - If a `TokenCredential` was passed through the constructor, the `getToken` scope is set to be "https://management.azure.com/.default".
    */
@@ -164,7 +164,7 @@ export class ServiceClient {
    * The base URI against which requests will be made when using this ServiceClient instance.
    *
    * This can be set either by setting the `baseUri` in the `options` parameter to the ServiceClient constructor or directly after constructing the ServiceClient.
-   * If set via the ServiceClient constructor when using the overload that takes the `TokenCredential`, this base URI sets the scope used to get the AAD token to `${baseUri}/.default` instead of the default "https://management.azure.com/.default"
+   * If set via the ServiceClient constructor when using the overload that takes the `TokenCredential`, and if it matches a known resource management endpoint, this base URI sets the scope used to get the AAD token to `${baseUri}/.default` instead of the default "https://management.azure.com/.default"
    *
    * If it is not specified, all OperationSpecs must contain a baseUrl property.
    */

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -187,7 +187,11 @@ export class ServiceClient {
 
     let serviceClientCredentials: ServiceClientCredentials | undefined;
     if (isTokenCredential(credentials)) {
-      serviceClientCredentials = new AzureIdentityCredentialAdapter(credentials);
+      const adapter = new AzureIdentityCredentialAdapter(credentials);
+      adapter.scopesSetter(() => {
+        return this.baseUri ? `${this.baseUri}/.default` : undefined;
+      });
+      serviceClientCredentials = adapter;
     } else {
       serviceClientCredentials = credentials;
     }

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -147,11 +147,11 @@ export interface ServiceClientOptions {
    */
   agentSettings?: AgentSettings;
   /**
-   * If specified, and if the value matches a known resource manager endpoint:
+   * If specified:
    * - This `baseUri` becomes the base URI that requests will be made against for this ServiceClient.
-   * - If a `TokenCredential` was passed through the constructor, this `baseUri` defines the `getToken` scope to be `${options.baseUri}/.default`.
+   * - If the `baseUri` matches a known resource manager endpoint and if a `TokenCredential` was passed through the constructor, this `baseUri` defines the `getToken` scope to be `${options.baseUri}/.default`. Otherwise, the scope would default to "https://management.azure.com/.default".
    *
-   * If it is not specified, or if it doesn't match a known resource manager endpoint:
+   * If it is not specified:
    * - All OperationSpecs must contain a baseUrl property.
    * - If a `TokenCredential` was passed through the constructor, the `getToken` scope is set to be "https://management.azure.com/.default".
    */

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -144,11 +144,11 @@ export interface ServiceClientOptions {
    */
   agentSettings?: AgentSettings;
   /**
-   * If specified:
+   * If specified, and if the value matches a resource management endpoint URI:
    * - This `baseUri` becomes the base URI that requests will be made against for this ServiceClient.
    * - If a `TokenCredential` was passed through the constructor, this `baseUri` defines the `getToken` scope to be `${options.baseUri}/.default`.
    *
-   * If it is not specified:
+   * If it is not specified, or if it doesn't match a resource management endpoint URI:
    * - All OperationSpecs must contain a baseUrl property.
    * - If a `TokenCredential` was passed through the constructor, the `getToken` scope is set to be "https://management.azure.com/.default".
    */

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -144,8 +144,13 @@ export interface ServiceClientOptions {
    */
   agentSettings?: AgentSettings;
   /**
-   * If specified, this is the base URI that requests will be made against for this ServiceClient.
-   * If it is not specified, then all OperationSpecs must contain a baseUrl property.
+   * If specified:
+   * - This `baseUri` becomes the base URI that requests will be made against for this ServiceClient.
+   * - If a `TokenCredential` was passed through the constructor, this `baseUri` defines the `getToken` scope to be `${options.baseUri}/.default`.
+   *
+   * If it is not specified:
+   * - All OperationSpecs must contain a baseUrl property.
+   * - If a `TokenCredential` was passed through the constructor, the `getToken` scope is set to be "https://management.azure.com/.default".
    */
   baseUri?: string;
 }
@@ -156,8 +161,13 @@ export interface ServiceClientOptions {
  */
 export class ServiceClient {
   /**
-   * If specified, this is the base URI that requests will be made against for this ServiceClient.
-   * If it is not specified, then all OperationSpecs must contain a baseUrl property.
+   * If specified:
+   * - This `baseUri` becomes the base URI that requests will be made against for this ServiceClient.
+   * - If a `TokenCredential` was passed through the constructor, this `baseUri` defines the `getToken` scope to be `${options.baseUri}/.default`.
+   *
+   * If it is not specified:
+   * - All OperationSpecs must contain a baseUrl property.
+   * - If a `TokenCredential` was passed through the constructor, the `getToken` scope is set to be "https://management.azure.com/.default".
    */
   protected baseUri?: string;
 

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -143,6 +143,11 @@ export interface ServiceClientOptions {
    * HTTP and HTTPS agents which will be used for every HTTP request (Node.js only).
    */
   agentSettings?: AgentSettings;
+  /**
+   * If specified, this is the base URI that requests will be made against for this ServiceClient.
+   * If it is not specified, then all OperationSpecs must contain a baseUrl property.
+   */
+  baseUri?: string;
 }
 
 /**
@@ -187,11 +192,10 @@ export class ServiceClient {
 
     let serviceClientCredentials: ServiceClientCredentials | undefined;
     if (isTokenCredential(credentials)) {
-      const adapter = new AzureIdentityCredentialAdapter(credentials);
-      adapter.scopesSetter(() => {
-        return this.baseUri ? `${this.baseUri}/.default` : undefined;
-      });
-      serviceClientCredentials = adapter;
+      serviceClientCredentials = new AzureIdentityCredentialAdapter(
+        credentials,
+        options?.baseUri ? `${options.baseUri}/.default` : undefined
+      );
     } else {
       serviceClientCredentials = credentials;
     }

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -205,10 +205,20 @@ export class ServiceClient {
 
     let serviceClientCredentials: ServiceClientCredentials | undefined;
     if (isTokenCredential(credentials)) {
-      serviceClientCredentials = new AzureIdentityCredentialAdapter(
-        credentials,
-        options?.baseUri ? `${options.baseUri}/.default` : undefined
-      );
+      let scope: string | undefined = undefined;
+      const azureManagementClouds = [
+        "https://management.core.windows.net",
+        "https://management.core.chinacloudapi.cn",
+        "https://management.core.usgovcloudapi.net",
+        "https://management.core.cloudapi.de",
+      ];
+      if (
+        options?.baseUri &&
+        azureManagementClouds.find((cloud) => options!.baseUri!.indexOf(cloud) > -1)
+      ) {
+        scope = `${options.baseUri}/.default`;
+      }
+      serviceClientCredentials = new AzureIdentityCredentialAdapter(credentials, scope);
     } else {
       serviceClientCredentials = credentials;
     }

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.5.4",
+  msRestVersion: "2.6.0",
 
   /**
    * Specifies HTTP.

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.5.3",
+  msRestVersion: "2.5.4",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.5.4",
+  "version": "2.6.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/test/serviceClientTests.ts
+++ b/test/serviceClientTests.ts
@@ -268,7 +268,7 @@ describe("ServiceClient", function () {
       },
     };
 
-    const scope = "https://management.core.chinacloudapi.cn";
+    const scope = "https://management.chinacloudapi.cn";
 
     class ServiceClientChildren extends ServiceClient {
       getBaseUri(): string | undefined {

--- a/test/serviceClientTests.ts
+++ b/test/serviceClientTests.ts
@@ -261,14 +261,14 @@ describe("ServiceClient", function () {
     assert.strictEqual(request!.withCredentials, true);
   });
 
-  it("The behavior of baseUri on ServiceClient children classes should be predictable", async function () {
+  it("The behavior of baseUri on ServiceClient children classes should be predictable on management clouds", async function () {
     const httpClient: HttpClient = {
       sendRequest: (request) => {
         return Promise.resolve({ request, status: 200, headers: new HttpHeaders() });
       },
     };
 
-    const scope = "https://original-scope.xyz";
+    const scope = "https://management.core.chinacloudapi.cn";
 
     class ServiceClientChildren extends ServiceClient {
       getBaseUri(): string | undefined {


### PR DESCRIPTION
Added a new property `baseUri` on the `ServiceClientOptions`, so that when a `TokenCredential` is sent to `ServiceClient`, it now automatically sets the scope of future token requests based on the `options.baseUri` property.

This should address https://github.com/Azure/azure-sdk-for-js/issues/15945