### PR TITLE
fix: :arrow_up: CVE-2022-0235

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.1 - (2022-01-25)
+
+- Fix a security issue with [CVE-2022-0235](https://github.com/advisories/GHSA-r683-j2x4-v87g) by upgrade [node-fetch](https://www.npmjs.com/package/node-fetch) (PR [459](https://github.com/Azure/ms-rest-js/pull/459))
+
 ## 2.6.0 - (2021-08-18)
 
 - Added a new property `baseUri` on the `ServiceClientOptions` that is then used to initialize the corresponding `baseUri` protected property on the `ServiceClient`.

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.6.0",
+  msRestVersion: "2.6.1",
 
   /**
    * Specifies HTTP.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@azure/core-auth": "^1.1.4",
     "abort-controller": "^3.0.0",
     "form-data": "^2.5.0",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.7",
     "tough-cookie": "^3.0.1",
     "tslib": "^1.10.0",
     "tunnel": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
update node-fetch to 2.6.7 to fix [CVE-2022-0235](https://snyk.io/vuln/npm:node-fetch)