### PR TITLE
Freeze chai version to 4.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@types/webpack-dev-middleware": "^2.0.3",
     "@types/xml2js": "^0.4.4",
     "abortcontroller-polyfill": "^1.3.0",
-    "chai": "^4.2.0",
+    "chai": "4.3.4",
     "cross-env": "^7.0.3",
     "express": "^4.17.1",
     "fetch-mock": "^7.3.3",


### PR DESCRIPTION
as later versions introduced changes that break tests on NodeJS v12 and later.