### PR TITLE
Match types version of uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/sinon": "^7.0.13",
     "@types/tough-cookie": "^2.3.5",
     "@types/tunnel": "0.0.1",
-    "@types/uuid": "^3.4.5",
+    "@types/uuid": "^8.3.2",
     "@types/webpack": "^4.4.34",
     "@types/webpack-dev-middleware": "^2.0.3",
     "@types/xml2js": "^0.4.4",


### PR DESCRIPTION
UUID was updated to 8.3.2, but @types/uuid was still using the 3.x version