### PR TITLE
Address Trusted Types compliance issue

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.2 - (2022-07-28)
+
+- Address Trusted Types compliance issue.
+
 ## 2.6.1 - (2022-01-25)
 
 - Fix a security issue with [CVE-2022-0235](https://github.com/advisories/GHSA-r683-j2x4-v87g) by upgrade [node-fetch](https://www.npmjs.com/package/node-fetch) (PR [459](https://github.com/Azure/ms-rest-js/pull/459))

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.6.1",
+  msRestVersion: "2.6.2",
 
   /**
    * Specifies HTTP.

--- a/lib/util/xml.ts
+++ b/lib/util/xml.ts
@@ -23,7 +23,7 @@ export function parseXML(str: string): Promise<any> {
     if (!str) {
       reject(new Error("Document is empty"));
     } else {
-      xmlParser.parseString(str, (err?: Error, res?: any) => {
+      xmlParser.parseString(str, (err: any, res: any) => {
         if (err) {
           reject(err);
         } else {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@types/semver": "^6.0.1",
     "@types/sinon": "^7.0.13",
     "@types/tough-cookie": "^2.3.5",
+    "@types/trusted-types": "^2.0.0",
     "@types/tunnel": "0.0.1",
     "@types/uuid": "^8.3.2",
     "@types/webpack": "^4.4.34",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
porting fix from PR https://github.com/Azure/azure-sdk-for-js/pull/22715

Trusted Types is/are a set of web APIs that give us the ability to control and
restrict data that flows into dangerous DOM APIs in our apps. Main goal of this
mechanism is to prevent successful exploitation of HTML and DOM-based
Cross-Site-Scripting (XSS) vulnerabilities.

https://github.com/w3c/webappsec-trusted-types

Our code does not parse HTML strings. The parsed DOM object is not exposed to
outside world either. This PR adds trusted types policies to make the parsing
code compliant at running time. Consumers of our packages can review and add the
policy to their allowed list.