### PR TITLE
Support parsing default responses

### DIFF
--- a/lib/policies/deserializationPolicy.ts
+++ b/lib/policies/deserializationPolicy.ts
@@ -95,7 +95,7 @@ function getOperationResponse(
           response: HttpOperationResponse
         ) => undefined | OperationResponse) = request.operationResponseGetter;
     if (!operationResponseGetter) {
-      result = operationSpec.responses[parsedResponse.status];
+      result = operationSpec.responses[parsedResponse.status] || operationSpec.responses.default;
     } else {
       result = operationResponseGetter(operationSpec, parsedResponse);
     }

--- a/lib/serviceClient.ts
+++ b/lib/serviceClient.ts
@@ -466,7 +466,7 @@ export class ServiceClient {
       }
 
       result = this.sendRequest(httpRequest).then((res) =>
-        flattenResponse(res, operationSpec.responses[res.status])
+        flattenResponse(res, operationSpec.responses[res.status] || operationSpec.responses.default)
       );
     } catch (error) {
       result = Promise.reject(error);

--- a/test/serviceClientTests.ts
+++ b/test/serviceClientTests.ts
@@ -521,6 +521,136 @@ describe("ServiceClient", function () {
     assert.deepStrictEqual(res, []);
   });
 
+  it("should deserialize response bodies with undefined array", async function () {
+    let request: WebResourceLike;
+    const httpClient: HttpClient = {
+      sendRequest: (req) => {
+        request = req;
+        return Promise.resolve({
+          request,
+          status: 400,
+          headers: new HttpHeaders(),
+          bodyAsText: JSON.stringify({ code: 400, message: 'simulated error' }),
+        });
+      },
+    };
+
+    const client1 = new ServiceClient(undefined, {
+      httpClient,
+      requestPolicyFactories: [deserializationPolicy()],
+    });
+
+    const res = (await client1.sendOperationRequest(
+      {},
+      {
+        serializer: new Serializer(),
+        httpMethod: "GET",
+        baseUrl: "httpbin.org",
+        responses: {
+          "200": {
+            bodyMapper: {
+              type: {
+                name: "Composite",
+                modelProperties: {
+                  value: {
+                    serializedName: "",
+                    type: {
+                      name: "Sequence",
+                      element: {
+                        type: { name: "String" },
+                      },
+                    },
+                  },
+                  nextLink: {
+                    serializedName: "nextLink",
+                    type: { name: "String" },
+                  },
+                },
+              },
+            },
+          },
+          default: {
+            bodyMapper: {
+              serializedName: "ErrorResponse",
+              type: {
+                name: "Composite",
+                className: "ErrorResponse",
+                modelProperties: {
+                  code: { serializedName: "code", type: { name: "String" } },
+                  message: {
+                    serializedName: "message",
+                    type: { name: "String" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+    )) as any;
+
+    assert.strictEqual(res._response.status, 400);
+    assert.deepStrictEqual(res.code, 400);
+    assert.deepStrictEqual(res.message, 'simulated error');
+  });
+
+  it("should deserialize response bodies with only default response", async function () {
+    let request: WebResourceLike;
+    const httpClient: HttpClient = {
+      sendRequest: (req) => {
+        request = req;
+        return Promise.resolve({
+          request,
+          status: 200,
+          headers: new HttpHeaders(),
+          bodyAsText: JSON.stringify({ nextLink: "mockLink" }),
+        });
+      },
+    };
+
+    const client1 = new ServiceClient(undefined, {
+      httpClient,
+      requestPolicyFactories: [deserializationPolicy()],
+    });
+
+    const res = (await client1.sendOperationRequest(
+      {},
+      {
+        serializer: new Serializer(),
+        httpMethod: "GET",
+        baseUrl: "httpbin.org",
+        responses: {
+          default: {
+            bodyMapper: {
+              type: {
+                name: "Composite",
+                modelProperties: {
+                  value: {
+                    serializedName: "",
+                    type: {
+                      name: "Sequence",
+                      element: {
+                        type: { name: "String" },
+                      },
+                    },
+                  },
+                  nextLink: {
+                    serializedName: "nextLink",
+                    type: { name: "String" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+    )) as any;
+
+    assert.strictEqual(res._response.status, 200);
+    assert.deepStrictEqual(res.nextLink, "mockLink");
+    assert.deepStrictEqual(res, []);
+  });
+
   it("should use userAgent header name value from options", async function () {
     const httpClient: HttpClient = {
       sendRequest: (request: WebResourceLike) => {


### PR DESCRIPTION
This PR adds support for a `default` response per the [Open API v3 specification](https://spec.openapis.org/oas/latest.html#responses-object).

- [x] The default MAY be used as a default response object for all HTTP codes that are not covered individually by the Responses Object.
- [x] The Responses Object MUST contain at least one response code, and if only one response code is provided it SHOULD be the response for a successful operation call.