### PR TITLE
Upgrade dev dependency typescript to v4.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.3 - (Unreleased)
+
+- Upgrade dev dependency `typescript` version to `~4.2.0`.
+
 ## 2.6.2 - (2022-07-28)
 
 - Address Trusted Types compliance issue.

--- a/lib/fetchHttpClient.ts
+++ b/lib/fetchHttpClient.ts
@@ -228,9 +228,9 @@ export abstract class FetchHttpClient implements HttpClient {
     }
   }
 
-  abstract async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>>;
-  abstract async processRequest(operationResponse: HttpOperationResponse): Promise<void>;
-  abstract async fetch(input: CommonRequestInfo, init?: CommonRequestInit): Promise<CommonResponse>;
+  abstract prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>>;
+  abstract processRequest(operationResponse: HttpOperationResponse): Promise<void>;
+  abstract fetch(input: CommonRequestInfo, init?: CommonRequestInit): Promise<CommonResponse>;
 }
 
 function isReadableStream(body: any): body is Readable {

--- a/lib/nodeFetchHttpClient.ts
+++ b/lib/nodeFetchHttpClient.ts
@@ -75,7 +75,7 @@ export class NodeFetchHttpClient extends FetchHttpClient {
     if (this.cookieJar) {
       const setCookieHeader = operationResponse.headers.get("Set-Cookie");
       if (setCookieHeader != undefined) {
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
           this.cookieJar!.setCookie(
             setCookieHeader,
             operationResponse.request.url,

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.6.2",
+  msRestVersion: "2.6.3",
 
   /**
    * Specifies HTTP.

--- a/lib/util/utils.ts
+++ b/lib/util/utils.ts
@@ -165,8 +165,10 @@ export function mergeObjects(source: { [key: string]: any }, target: { [key: str
  * @param {T} value The value to be resolved with after a timeout of t milliseconds.
  * @returns {Promise<T>} Resolved promise
  */
-export function delay<T>(t: number, value?: T): Promise<T> {
-  return new Promise((resolve) => setTimeout(() => resolve(value), t));
+export function delay<T>(t: number, value?: T): Promise<T | void> {
+  return new Promise<T | void>((resolve) =>
+    setTimeout(() => (value === undefined ? resolve() : resolve(value)), t)
+  );
 }
 
 /**

--- a/lib/util/xml.browser.ts
+++ b/lib/util/xml.browser.ts
@@ -18,7 +18,10 @@ if (typeof self.trustedTypes !== "undefined") {
 
 export function parseXML(str: string): Promise<any> {
   try {
-    const dom = parser.parseFromString((ttPolicy?.createHTML(str) ?? str) as string, "application/xml");
+    const dom = parser.parseFromString(
+      (ttPolicy?.createHTML(str) ?? str) as string,
+      "application/xml"
+    );
     throwIfError(dom);
 
     const obj = domToObject(dom.childNodes[0]);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",
@@ -56,7 +56,7 @@
     "form-data": "^2.5.0",
     "node-fetch": "^2.6.7",
     "tough-cookie": "^3.0.1",
-    "tslib": "^1.10.0",
+    "tslib": "^2.4.0",
     "tunnel": "0.0.6",
     "uuid": "^8.3.2",
     "xml2js": "^0.4.19"
@@ -121,7 +121,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "^3.5.2",
+    "typescript": "~4.2.0",
     "webpack": "^4.35.2",
     "webpack-cli": "^3.3.5",
     "webpack-dev-middleware": "^3.7.0",


### PR DESCRIPTION
So that it can understand string interpolations included in dependency's newer version of type definitions (@types/express-serve-static-core/index.d.ts)