### PR TITLE
Wrap trusted-types policy creation in a try/catch

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.6.4 - (2022-11-15)
+
+- Wrap Trusted Types policy-creation in a try/catch.
+
 ## 2.6.2 - (2022-07-28)
 
 - Address Trusted Types compliance issue.

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  msRestVersion: "2.6.3",
+  msRestVersion: "2.6.4",
 
   /**
    * Specifies HTTP.

--- a/lib/util/xml.browser.ts
+++ b/lib/util/xml.browser.ts
@@ -10,10 +10,14 @@ const parser = new DOMParser();
 // according to the spec.  There are no HTML/XSS security concerns on the usage of
 // parseFromString() here.
 let ttPolicy: Pick<TrustedTypePolicy, "createHTML"> | undefined;
-if (typeof self.trustedTypes !== "undefined") {
-  ttPolicy = self.trustedTypes.createPolicy("@azure/ms-rest-js#xml.browser", {
-    createHTML: (s) => s,
-  });
+try {
+  if (typeof self.trustedTypes !== "undefined") {
+    ttPolicy = self.trustedTypes.createPolicy("@azure/ms-rest-js#xml.browser", {
+      createHTML: (s) => s,
+    });
+  }
+} catch (e) {
+  console.warn('Could not create trusted types policy "@azure/ms-rest-js#xml.browser"');
 }
 
 export function parseXML(str: string): Promise<any> {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/ms-rest-js"
   },
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",


### PR DESCRIPTION
In our use-case of the ms-rest-js library, we have a large existing application (complete with caching, service-workers, etc) that we dynamically load additional JavaScript code into. The additional JS is what brings in the ms-rest-js.

The application has Trusted Types enabled (e.g., CSP rule `'trusted-types LibraryA LibraryB etc`). But, interestingly, its `require-trusted-types-for 'script'` is currently under "report only" (`Content-Security-Policy-Report-Only`). In those cases, a call to `trustedTypes.createPolicy` will fail because the policy isn't on the allowed-list, even though _skipping_ the `createPolicy` would be OK. So in effect, https://github.com/Azure/ms-rest-js/commit/531aea9bfbbe6ef6c06984ab06f99775b90923ca introduced a regression.

We are working on extending the allow-list of our application to include `@azure/ms-rest-js#xml.browser`, but that change takes time. In the meantime, we'd like to wrap the policy-creation in a `try/catch`. There is no security risk to it, since for host applications that DO have strict enforcement of trusted-types, the code will simply fail when the dangerous sink is used (e.g., when doing `parseFromString`). And likewise, wrapping in `try/catch` and doing nothing on `catch` is OK, because the code already deals with the possibility of the trustedTypes API not being available on the browser.