### PR TITLE
Pin the indirect dev dependency `@types/bluebird` version to 3.5.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@azure/logger-js": "^1.1.0",
     "@microsoft/api-extractor": "^7.18.11",
     "@ts-common/azure-js-dev-tools": "^19.4.0",
+    "@types/bluebird": "3.5.36",
     "@types/chai": "^4.1.7",
     "@types/express": "4.17.0",
     "@types/express-serve-static-core": "4.17.0",


### PR DESCRIPTION
As newer versions contain syntax not recognized by TypeScript v3.9.

It is not straightforward to upgrade TypeScript version because another dev dependency `tslint-eslint-rules` requires TypeScript v3.