### PR TITLE
Upgrade tough-cookie to 4.3.1 to fix security vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "abort-controller": "^3.0.0",
     "form-data": "^2.5.0",
     "node-fetch": "^2.6.7",
-    "tough-cookie": "^3.0.1",
+    "tough-cookie": "^4.1.3",
     "tslib": "^1.10.0",
     "tunnel": "0.0.6",
     "uuid": "^8.3.2",


### PR DESCRIPTION
This addresses #483. There is a security vulnerability in the `tough-cookie` package for versions `<4.3.1` - see [https://nvd.nist.gov/vuln/detail/CVE-2023-26136]. Previously `@azure/ms-rest-js` depended on `^3.0.0`, which locked `tough-cookie` to an unsecure version.

### Testing

All tests (`npm run test`) continue to pass with this upgrade. In addition I reviewed the [release notes for `tough-cookie@4.0.0`][https://github.com/salesforce/tough-cookie/releases/tag/v4.0.0] (the breaking change from `3.x`). Here they are (annotated with **[astegmaier]**), with why I believe they will not break `@azure/ms-rest-js`:

- Modernized JS Syntax
    - Use ESLint and Prettier to apply consistent, modern formatting (add dependency on `universalify`, `eslint` and `prettier`) - **[astegmaier] eslint and prettier are devDependencies of `tough-cookie` so they shouldn't break consumers. `universalify` seems to be aimed at backward-compatible usage**
 - Upgraded version dependencies for `psl` and `async` - **[astegmaier] `async` is a devDependency of `tough-cookie`, so an upgrade shouldn't break consumers. `psl` also seems to be a pretty benign dependency**
 - Re-order parameters for `findCookies()` - callback fn has to be last in order to comply with `universalify` **[astegmaier] it doesn't look like `@azure/ms-rest-js` uses `findCookies` anywhere`**
 - Use Classes instead of function prototypes to define classes
     - Might break people using `.call()` to do inheritance using function prototypes - **[astegmaier] it doesn't look like `@azurems-rest-js uses this pattern anywhere**

